### PR TITLE
Update LabelStores when entity label is not provided

### DIFF
--- a/src/execution_plan/ops/op_update.h
+++ b/src/execution_plan/ops/op_update.h
@@ -15,9 +15,9 @@
 #include "../../arithmetic/arithmetic_expression.h"
 
 typedef struct {
-    char *alias;        /* Entity alias. */
-    char *property;     /* Property to update. */
-    AR_ExpNode *exp;    /* Expression to evaluate. */
+    char *property;      /* Property to update. */
+    AST_GraphEntity *ge; /* Entity described by query. */
+    AR_ExpNode *exp;     /* Expression to evaluate. */
 } EntityUpdateEvalCtx;
 
 typedef struct {

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -150,6 +150,19 @@ LabelStore* GraphContext_AddRelationType(GraphContext *gc, const char *label) {
   return store;
 }
 
+// Find the offset of the label store for the provided node.
+// TODO Will only return the first match (if any), which will not be adequate
+// when we implement multi-label
+LabelStore* GraphContext_FindNodeLabel(const GraphContext *gc, NodeID id) {
+  for (int i = 0; i < gc->label_count; i ++) {
+    GrB_Matrix M = Graph_GetLabel(gc->g, i);
+    bool has_label = false;
+    GrB_Matrix_extractElement_BOOL(&has_label, M, id, id);
+    if (has_label) return gc->node_stores[i];
+  }
+  return NULL;
+}
+
 //------------------------------------------------------------------------------
 // Index API
 //------------------------------------------------------------------------------

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -45,6 +45,8 @@ LabelStore* GraphContext_GetStore(const GraphContext *gc, const char *label, Lab
 LabelStore* GraphContext_AddLabel(GraphContext *gc, const char *label);
 // Add a new store and matrix for the given relation type 
 LabelStore* GraphContext_AddRelationType(GraphContext *gc, const char *label);
+// Given a Node ID, return the LabelStore it is associated with.
+LabelStore* GraphContext_FindNodeLabel(const GraphContext *gc, NodeID id);
 
 /* Index API */
 bool GraphContext_HasIndices(GraphContext *gc);

--- a/tests/flow/test_unlabeled_operations.py
+++ b/tests/flow/test_unlabeled_operations.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import unittest
+from redisgraph import Graph, Node, Edge
+
+# import redis
+from .disposableredis import DisposableRedis
+
+from base import FlowTestsBase
+
+redis_graph = None
+male = ["Roi", "Alon", "Omri"]
+female = ["Hila", "Lucy"]
+
+def redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class UnlabeledOperationsFlowTest(FlowTestsBase):
+    @classmethod
+    def setUpClass(cls):
+        print "UnlabeledOperationsFlowTest"
+        global redis_graph
+        cls.r = redis()
+        cls.r.start()
+        redis_con = cls.r.client()
+        redis_graph = Graph("G", redis_con)
+
+        cls.populate_graph()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+
+    @classmethod
+    def populate_graph(cls):
+        redis_graph
+        
+        nodes = {}
+         # Create entities
+        
+        for m in male:
+            node = Node(label="male", properties={"name": m, "gender": "M"})
+            redis_graph.add_node(node)
+            nodes[m] = node
+        
+        for f in female:
+            node = Node(label="female", properties={"name": f, "gender": "F"})
+            redis_graph.add_node(node)
+            nodes[f] = node
+
+        for n in nodes:
+            for m in nodes:
+                if n == m: continue
+                edge = Edge(nodes[n], "knows", nodes[m])
+                redis_graph.add_edge(edge)
+
+        redis_graph.commit()
+
+    def test01_unlabeled_property_additions(self):
+        query = """MATCH (a) SET a.newprop = a.gender"""
+        actual_result = redis_graph.query(query)
+        assert (actual_result.properties_set == 5)
+
+    def test02_unlabeled_schema_after_addition(self):
+        query = """MATCH (a) RETURN a"""
+        actual_result = redis_graph.query(query)
+        assert "a.newprop" in actual_result.result_set[0]
+        for entry in actual_result.result_set:
+            assert (len(entry) == 3)
+
+    def test03_labeled_schema_after_addition(self):
+        query = """MATCH (a:female) RETURN a"""
+        actual_result = redis_graph.query(query)
+        assert "a.newprop" in actual_result.result_set[0]
+        for entry in actual_result.result_set:
+            assert (len(entry) == 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a lot more triemap updates in SET operations than we had before, which I don't love. If we were to postpone the updates until the Free routine, though, we would need to hold onto the new property strings as well as either the entity IDs or stores that are now associated with them.

I left the AllStore updates where they had been previously to minimize the amount of redundant effort spent there.

This PR does not resolve updates to relation type stores.