### PR TITLE
Add OpenMP to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM redis:latest as builder
 
-ENV DEPS "python python-setuptools python-pip wget build-essential cmake"
+ENV DEPS "python python-setuptools python-pip wget build-essential cmake libomp-dev"
 
 # Set up a build environment
 RUN set -ex;\


### PR DESCRIPTION
This _might_ resolve an issue @K-Jo reported with our Docker images:
```
➜  oss cat graph.js
#!/bin/sh
. version.properties

docker run --name redis-oss -d -p 6379:6379 redislabs/redisgraph:edge
➜  oss ./graph.js
1079a513da98c7dfae76a26ec24c3fe90211c1c899934a15463278f90a838039
➜  oss docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
➜  oss docker ps -a
CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS                     PORTS               NAMES
1079a513da98        redislabs/redisgraph:edge   "docker-entrypoint.s…"   10 seconds ago      Exited (1) 8 seconds ago                       redis-oss
➜  oss docker logs 1079a513da98
1:C 02 Nov 2018 22:03:03.427 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 02 Nov 2018 22:03:03.427 # Redis version=5.0.0, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 02 Nov 2018 22:03:03.427 # Configuration loaded
1:M 02 Nov 2018 22:03:03.427 * Running mode=standalone, port=6379.
1:M 02 Nov 2018 22:03:03.428 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
1:M 02 Nov 2018 22:03:03.428 # Server initialized
1:M 02 Nov 2018 22:03:03.428 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
1:M 02 Nov 2018 22:03:03.428 # Module /usr/lib/redis/modules/redisgraph.so failed to load: libgomp.so.1: cannot open shared object file: No such file or directory
1:M 02 Nov 2018 22:03:03.428 # Can't load module from /usr/lib/redis/modules/redisgraph.so: server aborting
```