### PR TITLE
Fixes around FLUSH logic

### DIFF
--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -56,8 +56,6 @@ void _MGraph_Delete(void *args) {
 
     // Retrieve the GraphContext to disable synchronization.
     GraphContext *gc = RedisModule_ModuleTypeGetValue(key);
-    // Lock the graph for writing.
-    Graph_AcquireWriteLock(gc->g);
     // Disable matrix synchronization for graph deletion.
     Graph_SetMatrixPolicy(gc->g, DISABLED);
 

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -215,9 +215,6 @@ Graph *Graph_New(size_t node_cap, size_t edge_cap) {
     // Force GraphBLAS updates and resize matrices to node count by default
     Graph_SetMatrixPolicy(g, SYNC_AND_MINIMIZE_SPACE);
 
-    // Graph_New can only be invoked from writing contexts
-    Graph_AcquireWriteLock(g);
-
     /* TODO: We might want a mutex per matrix,
      * such that when a thread is resizing matrix A
      * another thread could be resizing matrix B. */
@@ -615,7 +612,6 @@ void Graph_Free(Graph *g) {
 
     // Destroy graph-scoped locks.
     pthread_mutex_destroy(&g->_mutex);
-    Graph_ReleaseLock(g);
     pthread_rwlock_destroy(&g->_rwlock);
 
     rm_free(g);

--- a/src/graph/serializers/serialize_graph.c
+++ b/src/graph/serializers/serialize_graph.c
@@ -281,5 +281,4 @@ void RdbLoadGraph(RedisModuleIO *rdb, Graph *g) {
 
     // Flush all pending changes to graphs.
     GrB_wait();
-    Graph_ReleaseLock(g);
 }

--- a/src/stores/store.c
+++ b/src/stores/store.c
@@ -6,13 +6,14 @@
 */
 
 #include "store.h"
+#include "../util/rmalloc.h"
 #include <assert.h>
 
 /* Creates a new LabelStore. */
 LabelStore* LabelStore_New(const char *label, int id) {
-    LabelStore *store = malloc(sizeof(LabelStore));
+    LabelStore *store = rm_malloc(sizeof(LabelStore));
     store->properties = NewTrieMap();
-    store->label = strdup(label);
+    store->label = rm_strdup(label);
     store->id = id;
     
     return store;
@@ -27,6 +28,6 @@ void LabelStore_UpdateSchema(LabelStore *store, int prop_count, char **propertie
 
 void LabelStore_Free(LabelStore *store) {
     TrieMap_Free(store->properties, TrieMap_NOP_CB);
-    if(store->label) free(store->label);
-    free(store);
+    if(store->label) rm_free(store->label);
+    rm_free(store);
 }


### PR DESCRIPTION
FLUSH commands will enter the Graph_Free routine without ever acquiring a lock, so I don't think it will ever be valid to unlock from that function. The only place we'd been relying on that was the GRAPH.DELETE operation, so I removed lock acquisition from there. It holds the GIL and removes the key, so I don't think it should be possible for there to be any races there.

I also moved the LabelStore allocations and frees (not including the triemaps') to use rmalloc.h. This is what they use in the serializer, so parity is important.