### PR TITLE
Serializer updates

### DIFF
--- a/src/graph/entities/edge.h
+++ b/src/graph/entities/edge.h
@@ -14,13 +14,6 @@
 #include "../../util/uthash.h"
 #include "../../../deps/GraphBLAS/Include/GraphBLAS.h"
 
-// Encapsulate the essence of an edge.
-typedef struct {
-    NodeID srcId;   	// Source node ID.
-    NodeID destId;  	// Destination node ID.
-    int64_t relationId; // Relation type ID.
-} EdgeDesc;
-
 /* TODO: note it is possible to get into an inconsistency
  * if we set src and srcNodeID to different nodes. */
 struct Edge {

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -183,19 +183,20 @@ void Graph_ApplyAllPending(Graph *g) {
 
     for(int i = 0; i < array_len(g->labels); i ++) {
       M = g->labels[i];
-      _Graph_ApplyPending(M);
+      g->SynchronizeMatrix(g, M);
     }
 
     for(int i = 0; i < array_len(g->relations); i ++) {
       M = g->relations[i];
-      _Graph_ApplyPending(M);
+      g->SynchronizeMatrix(g, M);
     }
 
     for(int i = 0; i < array_len(g->_relations_map); i ++) {
       M = g->_relations_map[i];
-      _Graph_ApplyPending(M);
+      g->SynchronizeMatrix(g, M);
     }
 }
+
 /*================================ Graph API ================================ */
 Graph *Graph_New(size_t node_cap, size_t edge_cap) {
     node_cap = MAX(node_cap, GRAPH_DEFAULT_NODE_CAP);

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -211,6 +211,7 @@ Graph *Graph_New(size_t node_cap, size_t edge_cap) {
 
     // Initialize a read-write lock scoped to the individual graph
     assert(pthread_rwlock_init(&g->_rwlock, NULL) == 0);
+    g->_writelocked = false;
 
     // Force GraphBLAS updates and resize matrices to node count by default
     Graph_SetMatrixPolicy(g, SYNC_AND_MINIMIZE_SPACE);

--- a/src/graph/serializers/serialize_store.c
+++ b/src/graph/serializers/serialize_store.c
@@ -23,11 +23,12 @@ void* RdbLoadStore(RedisModuleIO *rdb) {
   s->id = RedisModule_LoadUnsigned(rdb);
   s->label = rm_strdup(RedisModule_LoadStringBuffer(rdb, NULL));
   s->properties = NewTrieMap();
-
+  size_t len = 0;
   uint64_t propCount = RedisModule_LoadUnsigned(rdb);
   char *propStrings[propCount];
   for(int i = 0; i < propCount; i++) {
-    propStrings[i] = RedisModule_LoadStringBuffer(rdb, NULL);
+    propStrings[i] = RedisModule_LoadStringBuffer(rdb, &len);
+    propStrings[i][len] = '\0';
   }
 
   LabelStore_UpdateSchema(s, propCount, propStrings);

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -29,6 +29,13 @@ extern "C"
 #define KRED "\x1B[31m"
 #define KNRM "\x1B[0m"
 
+// Encapsulate the essence of an edge.
+typedef struct {
+    NodeID srcId;   	// Source node ID.
+    NodeID destId;  	// Destination node ID.
+    int64_t relationId; // Relation type ID.
+} EdgeDesc;
+
 class GraphTest : public ::testing::Test
 {
   protected:


### PR DESCRIPTION
I believe that the changes to property store deserialization here will resolve issues MOD-114 and MOD-115. `RedisModule_LoadStringBuffer` does not null-terminate strings; rather, it stores the length along with the byte sequence. We usually resolve this by serializing `strlen(x) + 1`, but that doesn't work in the context of triemaps, as they are not null-terminated by default either.

This has never proven to be an issue on my platform, so I can't be 100% certain about the fix, but the change introduced here resolved relevant Valgrind warnings.

I switched Graph deserialization to logic more similar to bulk ops, allocating to capacity and resizing/syncing at the end of the function.
Loading about 2.4 million nodes and 10 million edges, the reported time to load from RDB was 2.131 seconds. (I got impatient while waiting for this to finish on master, so I don't have a strict numeric comparison, but it's apparently a lot better.)
Ask for retest of RED-23806 after this.