### PR TITLE
Don't attempt to look up stores from empty strings

### DIFF
--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -135,16 +135,18 @@ void _UpdateSchemas(const OpUpdate *op) {
 
         /* Locate node label. */
         AST_GraphEntity* ge = MatchClause_GetEntity(op->ast->matchNode, entityAlias);
-        char *l = ge->label;
+        LabelStoreType t = (ge->t == N_ENTITY) ? STORE_NODE : STORE_EDGE;
+        LabelStore *allStore = GraphContext_AllStore(op->gc, t);
+        LabelStore_UpdateSchema(allStore, 1, &entityProp);
+
         // TODO If the match clause does not provide a label, we must update all the stores
         // affected by the SET clause.
-        LabelStoreType t = (ge->t == N_ENTITY) ? STORE_NODE : STORE_EDGE;
+        char *l = ge->label;
+        if (!l) continue;
         LabelStore *store = GraphContext_GetStore(op->gc, l, t);
         if (!store) continue;
 
-        LabelStore *allStore = GraphContext_AllStore(op->gc, t);
         LabelStore_UpdateSchema(store, 1, &entityProp);
-        LabelStore_UpdateSchema(allStore, 1, &entityProp);
     }
 }
 


### PR DESCRIPTION
`GraphContext_GetStore` doesn't NULL-check strings (nor do I think it should need to). This PR always updates the allstore, and ensures that we don't crash on trying to retrieve a non-existent specific store.