### PR TITLE
GA index updates

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -34,7 +34,7 @@ void _index_operation(RedisModuleCtx *ctx, GraphContext *gc, AST_IndexNode *inde
   switch(indexNode->operation) {
     case CREATE_INDEX:
       if (GraphContext_AddIndex(gc, indexNode->label, indexNode->property) != INDEX_OK) {
-        // Index creation may have failed if the specified label or property was invalid.
+        // Index creation may have failed if the label or property was invalid, or the index already exists.
         RedisModule_ReplyWithSimpleString(ctx, "(no changes, no records)");
         break;
       }

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -33,17 +33,12 @@ void _index_operation(RedisModuleCtx *ctx, GraphContext *gc, AST_IndexNode *inde
 
   switch(indexNode->operation) {
     case CREATE_INDEX:
-      if (GraphContext_GetIndex(gc, indexNode->label, indexNode->property)) {
-        // Index already exists on label-property pair.
+      if (GraphContext_AddIndex(gc, indexNode->label, indexNode->property) != INDEX_OK) {
+        // Index creation may have failed if the specified label or property was invalid.
         RedisModule_ReplyWithSimpleString(ctx, "(no changes, no records)");
-      } else {
-        if (GraphContext_AddIndex(gc, indexNode->label, indexNode->property) != INDEX_OK) {
-          // Index creation may have failed if the specified label or property was invalid.
-          RedisModule_ReplyWithSimpleString(ctx, "(no changes, no records)");
-          break;
-        }
-        RedisModule_ReplyWithSimpleString(ctx, "Added 1 index.");
+        break;
       }
+      RedisModule_ReplyWithSimpleString(ctx, "Added 1 index.");
       break;
     case DROP_INDEX:
       if (GraphContext_DeleteIndex(gc, indexNode->label, indexNode->property) == INDEX_OK) {

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -390,7 +390,7 @@ ExecutionPlan* NewExecutionPlan(RedisModuleCtx *ctx,
     }
 
     if(ast->deleteNode) {
-        OpBase *opDelete = NewDeleteOp(ast->deleteNode, q, g, execution_plan->result_set);
+        OpBase *opDelete = NewDeleteOp(ast->deleteNode, q, gc, execution_plan->result_set);
         Vector_Push(ops, opDelete);
     }
 

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -175,7 +175,10 @@ static void _CommitNodes(OpCreate *op) {
                 }
 
                 GraphEntity_Add_Properties((GraphEntity*)n, propCount/2, keys, values);
-                if(store) LabelStore_UpdateSchema(store, propCount/2, keys);
+                if(store) {
+                    LabelStore_UpdateSchema(store, propCount/2, keys);
+                    GraphContext_AddNodeToIndices(op->gc, store, n);
+                }
                 LabelStore_UpdateSchema(allStore, propCount/2, keys);
                 op->result_set->stats.properties_set += propCount/2;
             }

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -62,29 +62,6 @@ void _LocateEntities(OpDelete *op, QueryGraph *qg, AST_DeleteNode *ast_delete_no
     }
 }
 
-EntityID *_SortNRemoveDups(EntityID *entities, size_t entityCount, size_t *dupFreeCount) {
-    // Sort.
-    QSORT(EntityID, entities, entityCount, ENTITY_ID_ISLT);
-
-    // Remove duplicates.
-    int j = 0;  // Index into dup_free_ids.
-
-    // Array of unique IDs.
-    EntityID *dup_free_ids = malloc(sizeof(EntityID) * entityCount);
-
-    for(int i = 0; i < entityCount; i++) {
-        EntityID current = entities[i];
-
-        // Skip duplicates.
-        while(i < (entityCount-1) && current == entities[i+1]) i++;
-
-        dup_free_ids[j++] = current;
-    }
-
-    *dupFreeCount = j;
-    return dup_free_ids;
-}
-
 void _DeleteEntities(OpDelete *op) {
     /* We must start with edge deletion as node deletion moves nodes around. */
     size_t deletedEdgeCount = array_len(op->deleted_edges);

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -19,10 +19,10 @@
 /* Forward declarations. */
 void _LocateEntities(OpDelete *op_delete, QueryGraph *graph, AST_DeleteNode *ast_delete_node);
 
-OpBase* NewDeleteOp(AST_DeleteNode *ast_delete_node, QueryGraph *qg, Graph *g, ResultSet *result_set) {
+OpBase* NewDeleteOp(AST_DeleteNode *ast_delete_node, QueryGraph *qg, GraphContext *gc, ResultSet *result_set) {
     OpDelete *op_delete = malloc(sizeof(OpDelete));
 
-    op_delete->g = g;
+    op_delete->gc = gc;
     op_delete->qg = qg;
     op_delete->node_count = 0;
     op_delete->edge_count = 0;
@@ -67,15 +67,17 @@ void _DeleteEntities(OpDelete *op) {
     size_t deletedEdgeCount = array_len(op->deleted_edges);
     for(int i = 0; i < deletedEdgeCount; i++) {
         Edge *e = op->deleted_edges + i;
-        if(Graph_DeleteEdge(op->g, e))
+        if(Graph_DeleteEdge(op->gc->g, e))
             if(op->result_set) op->result_set->stats.relationships_deleted++;
     }
 
     size_t deletedNodeCount = array_len(op->deleted_nodes);
     for(int i = 0; i < deletedNodeCount; i++) {
         Node *n = op->deleted_nodes + i;
-        if(Graph_DeleteNode(op->g, n))
+        GraphContext_DeleteNodeFromIndices(op->gc, n);
+        if (Graph_DeleteNode(op->gc->g, n)) {
             if(op->result_set) op->result_set->stats.nodes_deleted++;
+        }
     }
 }
 
@@ -117,3 +119,4 @@ void OpDeleteFree(OpBase *ctx) {
     array_free(op->deleted_nodes);
     array_free(op->deleted_edges);
 }
+

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -74,10 +74,9 @@ void _DeleteEntities(OpDelete *op) {
     size_t deletedNodeCount = array_len(op->deleted_nodes);
     for(int i = 0; i < deletedNodeCount; i++) {
         Node *n = op->deleted_nodes + i;
-        GraphContext_DeleteNodeFromIndices(op->gc, n);
-        if (Graph_DeleteNode(op->gc->g, n)) {
-            if(op->result_set) op->result_set->stats.nodes_deleted++;
-        }
+        GraphContext_DeleteNodeFromIndices(op->gc, NULL, n);
+        Graph_DeleteNode(op->gc->g, n);
+        if(op->result_set) op->result_set->stats.nodes_deleted++;
     }
 }
 

--- a/src/execution_plan/ops/op_delete.h
+++ b/src/execution_plan/ops/op_delete.h
@@ -17,7 +17,7 @@
 
 typedef struct {
     OpBase op;
-    Graph *g;
+    GraphContext *gc;
     QueryGraph *qg;
     size_t node_count;
     size_t edge_count;
@@ -29,7 +29,7 @@ typedef struct {
     ResultSet *result_set;
 } OpDelete;
 
-OpBase* NewDeleteOp(AST_DeleteNode *ast_delete_node, QueryGraph *qg, Graph *g, ResultSet *result_set);
+OpBase* NewDeleteOp(AST_DeleteNode *ast_delete_node, QueryGraph *qg, GraphContext *gc, ResultSet *result_set);
 OpResult OpDeleteConsume(OpBase *opBase, Record *r);
 OpResult OpDeleteReset(OpBase *ctx);
 void OpDeleteFree(OpBase *ctx);

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -14,9 +14,9 @@ OpBase *NewNodeByLabelScanOp(GraphContext *gc, Node *node) {
     nodeByLabelScan->_zero_matrix = NULL;
 
     /* Find out label matrix ID. */
-    int label_id = GraphContext_GetLabelID(gc, node->label, STORE_NODE);
-    if(label_id >= 0) {
-        nodeByLabelScan->iter = TuplesIter_new(Graph_GetLabel(gc->g, label_id));
+    LabelStore *store = GraphContext_GetStore(gc, node->label, STORE_NODE);
+    if (store) {
+        nodeByLabelScan->iter = TuplesIter_new(Graph_GetLabel(gc->g, store->id));
     } else {
         /* Label does not exist, use a fake empty matrix. */
         GrB_Matrix_new(&nodeByLabelScan->_zero_matrix, GrB_BOOL, 1, 1);

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -44,12 +44,14 @@ void _OpUpdate_BuildUpdateEvalCtx(OpUpdate* op, AST_SetNode *setNode) {
 
     for(int i = 0; i < op->update_expressions_count; i++) {
         AST_SetElement *element;
+        /* Get a reference to the entity in the SET clause. */
         Vector_Get(setNode->set_elements, i, &element);
 
-        /* Get a reference to the updated entity. */
-        op->update_expressions[i].alias = element->entity->alias;
         op->update_expressions[i].property = element->entity->property;
         op->update_expressions[i].exp = AR_EXP_BuildFromAST(element->exp);
+
+        /* Track the parallel AST entity in the MATCH clause. */
+        op->update_expressions[i].ge = MatchClause_GetEntity(op->ast->matchNode, element->entity->alias);
     }
 }
 
@@ -85,13 +87,13 @@ OpResult OpUpdateConsume(OpBase *opBase, Record *r) {
     for(int i = 0; i < op->update_expressions_count; i++, update_expression++) {
         SIValue new_value = AR_EXP_Evaluate(update_expression->exp, *r);
         /* Find ref to property. */
-        SIValue entry = Record_GetEntry(*r, update_expression->alias);
+        SIValue entry = Record_GetEntry(*r, update_expression->ge->alias);
         GraphEntity *entity = (GraphEntity*) entry.ptrval;
-        AST_GraphEntity* ge = MatchClause_GetEntity(op->ast->matchNode, update_expression->alias);
         int j = 0;
         for(; j < ENTITY_PROP_COUNT(entity); j++) {
             if(strcmp(ENTITY_PROPS(entity)[j].name, update_expression->property) == 0) {
-                _OpUpdate_QueueUpdate(op, entity->entity->id, ge->t, &ENTITY_PROPS(entity)[j], new_value);
+                _OpUpdate_QueueUpdate(op, entity->entity->id, update_expression->ge->t,
+                                      &ENTITY_PROPS(entity)[j], new_value);
                 break;
             }
         }
@@ -101,7 +103,8 @@ OpResult OpUpdateConsume(OpBase *opBase, Record *r) {
              * For the time being set the new property value to PROPERTY_NOTFOUND.
              * Once we commit the update, we'll set the actual value. */
             GraphEntity_Add_Properties(entity, 1, &update_expression->property, PROPERTY_NOTFOUND);
-            _OpUpdate_QueueUpdate(op, entity->entity->id, ge->t, &ENTITY_PROPS(entity)[ENTITY_PROP_COUNT(entity)-1], new_value);
+            _OpUpdate_QueueUpdate(op, entity->entity->id, update_expression->ge->t,
+                                  &ENTITY_PROPS(entity)[ENTITY_PROP_COUNT(entity)-1], new_value);
         }
     }
 
@@ -119,7 +122,9 @@ void _UpdateEntities(OpUpdate *op) {
         entity_to_update = &op->entities_to_update[i];
         EntityProperty *dest_entity_prop = entity_to_update->dest_entity_prop;
         SIValue new_value = entity_to_update->new_value;
-        if (entity_to_update->t == N_ENTITY) GraphContext_UpdateNodeIndices(op->gc, entity_to_update->id, dest_entity_prop, &new_value);
+        if (entity_to_update->t == N_ENTITY) {
+          GraphContext_UpdateNodeIndices(op->gc, NULL, entity_to_update->id, dest_entity_prop, &new_value);
+        }
         dest_entity_prop->value = new_value;
     }
     if(op->result_set)
@@ -131,16 +136,13 @@ void _UpdateEntities(OpUpdate *op) {
  * We have to update our schemas to track newly created properties. */
 void _UpdateSchemas(const OpUpdate *op) {
 
-    AST_SetNode *setNode = op->ast->setNode;
+    EntityUpdateEvalCtx update_expression;
     for(int i = 0; i < op->update_expressions_count; i++) {
-        AST_SetElement *setElement;
+        update_expression = op->update_expressions[i];
+        char *entityProp = update_expression.property;
 
-        Vector_Get(setNode->set_elements, i, &setElement);
-        char *entityAlias = setElement->entity->alias;
-        char *entityProp = setElement->entity->property;
-
-        /* Locate node label. */
-        AST_GraphEntity* ge = MatchClause_GetEntity(op->ast->matchNode, entityAlias);
+        /* Update store associated with the entity type. */
+        AST_GraphEntity *ge = update_expression.ge;
         LabelStoreType t = (ge->t == N_ENTITY) ? STORE_NODE : STORE_EDGE;
         LabelStore *allStore = GraphContext_AllStore(op->gc, t);
         LabelStore_UpdateSchema(allStore, 1, &entityProp);
@@ -149,6 +151,7 @@ void _UpdateSchemas(const OpUpdate *op) {
         // affected by the SET clause.
         char *l = ge->label;
         if (!l) continue;
+        /* Update store associated with the entity label. */
         LabelStore *store = GraphContext_GetStore(op->gc, l, t);
         if (!store) continue;
 
@@ -169,3 +172,4 @@ void OpUpdateFree(OpBase *ctx) {
     free(op->update_expressions);
     free(op->entities_to_update);
 }
+

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -122,7 +122,7 @@ void _UpdateEntities(OpUpdate *op) {
         entity_to_update = &op->entities_to_update[i];
         // Retrieve variables from update context
         Entity *entity = entity_to_update->entity_reference;
-        EntityProperty *dest_entity_prop = &entity->properties[entity_to_update->prop_idx];
+        EntityProperty *property = &entity->properties[entity_to_update->prop_idx];
         SIValue new_value = entity_to_update->new_value;
 
         // Only worry about index updates for nodes right now
@@ -130,9 +130,9 @@ void _UpdateEntities(OpUpdate *op) {
         if (ge->t == N_ENTITY) {
           LabelStore *store = NULL;
           if (ge->label) store = GraphContext_GetStore(op->gc, ge->label, STORE_NODE);
-          GraphContext_UpdateNodeIndices(op->gc, store, entity->id, dest_entity_prop, &new_value);
+          GraphContext_UpdateNodeIndices(op->gc, store, entity->id, property, &new_value);
         }
-        dest_entity_prop->value = new_value;
+        property->value = new_value;
     }
     if(op->result_set)
         op->result_set->stats.properties_set = op->entities_to_update_count;

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -59,7 +59,7 @@ void _OpUpdate_BuildUpdateEvalCtx(OpUpdate* op, AST_SetNode *setNode) {
  * more than once, we'll have to delay updates until all entities 
  * are processed, and so _OpUpdate_QueueUpdate will queue up 
  * all information necessary to perform an update. */
-void _OpUpdate_QueueUpdate(OpUpdate *op, EntityID id, AST_GraphEntityType t, EntityProperty *dest_entity_prop, SIValue new_value) {
+void _OpUpdate_QueueUpdate(OpUpdate *op, Entity *entity, AST_GraphEntity *ge, int prop_idx, SIValue new_value) {
     /* Make sure we've got enough room in queue. */
     if(op->entities_to_update_count == op->entities_to_update_cap) {
         op->entities_to_update_cap *= 2;
@@ -68,9 +68,9 @@ void _OpUpdate_QueueUpdate(OpUpdate *op, EntityID id, AST_GraphEntityType t, Ent
     }
 
     int i = op->entities_to_update_count;
-    op->entities_to_update[i].id = id;
-    op->entities_to_update[i].t = t;
-    op->entities_to_update[i].dest_entity_prop = dest_entity_prop;
+    op->entities_to_update[i].entity_reference = entity;
+    op->entities_to_update[i].ge = ge;
+    op->entities_to_update[i].prop_idx = prop_idx;
     op->entities_to_update[i].new_value = new_value;
     op->entities_to_update_count++;
 }
@@ -92,8 +92,8 @@ OpResult OpUpdateConsume(OpBase *opBase, Record *r) {
         int j = 0;
         for(; j < ENTITY_PROP_COUNT(entity); j++) {
             if(strcmp(ENTITY_PROPS(entity)[j].name, update_expression->property) == 0) {
-                _OpUpdate_QueueUpdate(op, entity->entity->id, update_expression->ge->t,
-                                      &ENTITY_PROPS(entity)[j], new_value);
+                _OpUpdate_QueueUpdate(op, entity->entity, update_expression->ge,
+                                      j, new_value);
                 break;
             }
         }
@@ -103,8 +103,8 @@ OpResult OpUpdateConsume(OpBase *opBase, Record *r) {
              * For the time being set the new property value to PROPERTY_NOTFOUND.
              * Once we commit the update, we'll set the actual value. */
             GraphEntity_Add_Properties(entity, 1, &update_expression->property, PROPERTY_NOTFOUND);
-            _OpUpdate_QueueUpdate(op, entity->entity->id, update_expression->ge->t,
-                                  &ENTITY_PROPS(entity)[ENTITY_PROP_COUNT(entity)-1], new_value);
+            _OpUpdate_QueueUpdate(op, entity->entity, update_expression->ge,
+                                  ENTITY_PROP_COUNT(entity)-1, new_value);
         }
     }
 
@@ -120,10 +120,17 @@ void _UpdateEntities(OpUpdate *op) {
     EntityUpdateCtx *entity_to_update;
     for(int i = 0; i < op->entities_to_update_count; i++) {
         entity_to_update = &op->entities_to_update[i];
-        EntityProperty *dest_entity_prop = entity_to_update->dest_entity_prop;
+        // Retrieve variables from update context
+        Entity *entity = entity_to_update->entity_reference;
+        EntityProperty *dest_entity_prop = &entity->properties[entity_to_update->prop_idx];
         SIValue new_value = entity_to_update->new_value;
-        if (entity_to_update->t == N_ENTITY) {
-          GraphContext_UpdateNodeIndices(op->gc, NULL, entity_to_update->id, dest_entity_prop, &new_value);
+
+        // Only worry about index updates for nodes right now
+        AST_GraphEntity *ge = entity_to_update->ge;
+        if (ge->t == N_ENTITY) {
+          LabelStore *store = NULL;
+          if (ge->label) store = GraphContext_GetStore(op->gc, ge->label, STORE_NODE);
+          GraphContext_UpdateNodeIndices(op->gc, store, entity->id, dest_entity_prop, &new_value);
         }
         dest_entity_prop->value = new_value;
     }

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -114,6 +114,7 @@ void _UpdateEntities(OpUpdate *op) {
     for(int i = 0; i < op->entities_to_update_count; i++) {
         EntityProperty *dest_entity_prop = op->entities_to_update[i].dest_entity_prop;
         SIValue new_value = op->entities_to_update[i].new_value;
+        // Ought to update indices here, though some information is missing
         dest_entity_prop->value = new_value;
     }
     if(op->result_set)

--- a/src/execution_plan/ops/op_update.h
+++ b/src/execution_plan/ops/op_update.h
@@ -21,10 +21,10 @@ typedef struct {
 } EntityUpdateEvalCtx;
 
 typedef struct {
-    EntityProperty *dest_entity_prop;   /* Entity's property to update. */
+    Entity *entity_reference;
+    int prop_idx;
     SIValue new_value;                  /* Constant value to set. */
-    EntityID id;
-    AST_GraphEntityType t;
+    AST_GraphEntity *ge;                /* Referred entity in MATCH clause. */
 } EntityUpdateCtx;
 
 typedef struct {

--- a/src/execution_plan/ops/op_update.h
+++ b/src/execution_plan/ops/op_update.h
@@ -15,9 +15,9 @@
 #include "../../arithmetic/arithmetic_expression.h"
 
 typedef struct {
-    char *alias;        /* Entity alias. */
-    char *property;     /* Property to update. */
-    AR_ExpNode *exp;    /* Expression to evaluate. */
+    AST_GraphEntity *ge; /* Referred entity in MATCH clause. */
+    char *property;      /* Property to update. */
+    AR_ExpNode *exp;     /* Expression to evaluate. */
 } EntityUpdateEvalCtx;
 
 typedef struct {

--- a/src/execution_plan/ops/op_update.h
+++ b/src/execution_plan/ops/op_update.h
@@ -23,6 +23,8 @@ typedef struct {
 typedef struct {
     EntityProperty *dest_entity_prop;   /* Entity's property to update. */
     SIValue new_value;                  /* Constant value to set. */
+    EntityID id;
+    AST_GraphEntityType t;
 } EntityUpdateCtx;
 
 typedef struct {
@@ -43,3 +45,4 @@ OpResult OpUpdateReset(OpBase *ctx);
 void OpUpdateFree(OpBase *ctx);
 
 #endif /* __OP_UPDATE_H */
+

--- a/src/graph/entities/edge.h
+++ b/src/graph/entities/edge.h
@@ -17,15 +17,15 @@
 /* TODO: note it is possible to get into an inconsistency
  * if we set src and srcNodeID to different nodes. */
 struct Edge {
-	Entity *entity;			// MUST be the first property of Edge.
-	char *alias;			// Alias attached to edge.
-	char* relationship;		// Label attached to edge.
-	int relationId;			// Label ID.
-	Node* src;				// Pointer to source node.
-	Node* dest;				// Pointer to destination node.
-	NodeID srcNodeID;		// Source node ID.
-	NodeID destNodeID;		// Destination node ID.
-	GrB_Matrix mat;			// Adjacency matrix, associated with edge.
+    Entity *entity;          /* MUST be the first property of Edge. */
+    char *alias;             /* Alias attached to edge. */
+    char* relationship;      /* Label attached to edge. */
+    int relationId;          /* Label ID. */
+    Node* src;               /* Pointer to source node. */
+    Node* dest;              /* Pointer to destination node. */
+    NodeID srcNodeID;        /* Source node ID. */
+    NodeID destNodeID;       /* Destination node ID. */
+    GrB_Matrix mat;          /* Adjacency matrix, associated with edge. */
 };
 
 typedef struct Edge Edge;

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -16,12 +16,12 @@
 /* Forward declaration of edge */
 struct Edge;
 typedef struct {
-	Entity *entity;			/* MUST be the first property of Edge. */
-	char *label;			/* label attached to node */
-	char *alias;			/* alias attached to node */
-	GrB_Matrix mat;			/* Label matrix, associated with node. */
-	Vector* outgoing_edges;	/* list of incoming edges (ME)<-(SRC) */
-	Vector* incoming_edges;	/* list on outgoing edges (ME)->(DEST) */
+    Entity *entity;             /* MUST be the first property of Edge. */
+    char *label;                /* label attached to node */
+    char *alias;                /* alias attached to node */
+    GrB_Matrix mat;             /* Label matrix, associated with node. */
+    Vector* outgoing_edges;     /* list of incoming edges (ME)<-(SRC) */
+    Vector* incoming_edges;     /* list on outgoing edges (ME)->(DEST) */
 } Node;
 
 /* Creates a new node. */

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -273,7 +273,7 @@ int Graph_GetEdge(const Graph *g, EdgeID id, Edge *e) {
     return (e->entity!=NULL);
 }
 
-int Graph_GetNodeLabel(const Graph *g, NodeID nodeID) {
+int Graph_GetLabelID(const Graph *g, NodeID nodeID) {
     assert(g);
     int label = GRAPH_NO_LABEL;
     for(int i = 0; i < array_len(g->labels); i++) {

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -480,12 +480,9 @@ int Graph_DeleteEdge(Graph *g, Edge *e) {
     return 1;
 }
 
-int Graph_DeleteNode(Graph *g, Node *n) {
+void Graph_DeleteNode(Graph *g, Node *n) {
     assert(g && n);
     
-    // Check to see if indeed node exists.
-    if(!DataBlock_GetItem(g->nodes, ENTITY_GET_ID(n))) return 0;
-
     // Delete incoming/outgoing edges of deleted node.
     Edge *e = NULL;
     Edge *edges = array_new(Edge, 32);
@@ -506,7 +503,6 @@ int Graph_DeleteNode(Graph *g, Node *n) {
 
     // Cleanup.
     array_free(edges);
-    return 1;
 }
 
 DataBlockIterator *Graph_ScanNodes(const Graph *g) {

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -179,7 +179,7 @@ int Graph_GetNode (
 
 // Retrieves node label
 // returns GRAPH_NO_LABEL if node has no label.
-int Graph_GetNodeLabel (
+int Graph_GetLabelID (
     const Graph *g,
     NodeID nodeID
 );

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -120,7 +120,7 @@ int Graph_ConnectNodes (
 );
 
 // Removes node and all of its connections within the graph.
-int Graph_DeleteNode (
+void Graph_DeleteNode (
     Graph *g,
     Node *node
 );

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -204,7 +204,7 @@ void GraphContext_DeleteNodeFromIndices(GraphContext *gc, LabelStore *store, Nod
       store = GraphContext_GetStore(gc, n->label, STORE_NODE);
     } else {
       // Otherwise, look up the offset of the matching label (if any)
-      int store_id = Graph_GetNodeLabel(gc->g, n->entity->id);
+      int store_id = Graph_GetLabelID(gc->g, n->entity->id);
       // Do nothing if node had no label
       if (store_id == GRAPH_NO_LABEL) return;
       store = gc->node_stores[store_id];
@@ -227,7 +227,7 @@ void GraphContext_UpdateNodeIndices(GraphContext *gc, LabelStore *store, NodeID 
 
   // If the query did not specify a label, retrieve the correct label store now
   if (store == NULL) {
-    int store_id = Graph_GetNodeLabel(gc->g, id);
+    int store_id = Graph_GetLabelID(gc->g, id);
     if (store_id == GRAPH_NO_LABEL) return;
     store = gc->node_stores[store_id];
   }

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -187,10 +187,9 @@ void GraphContext_AddNodeToIndices(GraphContext *gc, LabelStore *store, Node *n)
   if (store && GraphContext_HasIndices(gc)) {
     EntityProperty *props = ENTITY_PROPS(n);
     for (int j = 0; j < ENTITY_PROP_COUNT(n); j ++) {
+      // If a property is indexed, update it to include the given node 
       Index *idx = _GraphContext_GetIndexFromStore(store, props[j].name);
-      if (idx) {
-        Index_InsertNode(idx, n->entity->id, &props[j].value);
-      }
+      if (idx) Index_InsertNode(idx, n->entity->id, &props[j].value);
     }
   }
 }

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -197,6 +197,20 @@ void GraphContext_AddNodeToIndices(GraphContext *gc, LabelStore *store, Node *n)
   }
 }
 
+// TODO inefficient
+void GraphContext_UpdateNodeIndices(GraphContext *gc, NodeID id, EntityProperty *prop, SIValue *newval) {
+    if (!GraphContext_HasIndices(gc)) return;
+
+    int store_id = Graph_GetNodeLabel(gc->g, id);
+    if (store_id == GRAPH_NO_LABEL) return;
+
+    LabelStore *store = gc->node_stores[store_id];
+    Index *idx = LabelStore_RetrieveValue(store, prop->name);
+
+    Index_DeleteNode(idx, id, &prop->value);
+    Index_InsertNode(idx, id, newval);
+}
+
 int GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n) {
   // Verify that node exists.
   if(!DataBlock_GetItem(gc->g->nodes, ENTITY_GET_ID(n))) return 0;

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -27,8 +27,6 @@ GraphContext* GraphContext_New(RedisModuleCtx *ctx, RedisModuleString *rs_name,
 GraphContext* GraphContext_Retrieve(RedisModuleCtx *ctx, RedisModuleString *rs_graph_name);
 
 /* LabelStore API */
-// Find the ID associated with a label for store and matrix access
-int GraphContext_GetLabelID(const GraphContext *gc, const char *label, LabelStoreType t);
 // Retrieve the generic store for node labels or relation types
 LabelStore* GraphContext_AllStore(const GraphContext *gc, LabelStoreType t);
 // Retrieve the specific store for the provided node label or relation type string

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -49,12 +49,10 @@ int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *pr
 
 // Add a single node to all indices its properties match
 void GraphContext_AddNodeToIndices(GraphContext *gc, LabelStore *store, Node *n);
-
-// Remove a single node property from an index and re-insert with new value
-void GraphContext_UpdateNodeIndices(GraphContext *gc, NodeID id, EntityProperty *prop, SIValue *newval);
-
 // Remove a single node from all indices that refer to it
-int GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n);
+void GraphContext_DeleteNodeFromIndices(GraphContext *gc, LabelStore *store, Node *n);
+// Remove a single node property from an index and re-insert with new value
+void GraphContext_UpdateNodeIndices(GraphContext *gc, LabelStore *store, NodeID id, EntityProperty *prop, SIValue *newval);
 
 // Free the GraphContext and all associated graph data
 void GraphContext_Free(GraphContext *gc);

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -47,6 +47,12 @@ int GraphContext_AddIndex(GraphContext *gc, const char *label, const char *prope
 // Remove and free an index
 int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *property);
 
+// Add a single node to all indices its properties match
+void GraphContext_AddNodeToIndices(GraphContext *gc, LabelStore *store, Node *n);
+
+// Remove a single node from all indices that refer to it
+int GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n);
+
 // Free the GraphContext and all associated graph data
 void GraphContext_Free(GraphContext *gc);
 

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -50,6 +50,8 @@ int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *pr
 // Add a single node to all indices its properties match
 void GraphContext_AddNodeToIndices(GraphContext *gc, LabelStore *store, Node *n);
 
+void GraphContext_UpdateNodeIndices(GraphContext *gc, NodeID id, EntityProperty *prop, SIValue *newval);
+
 // Remove a single node from all indices that refer to it
 int GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n);
 

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -50,6 +50,7 @@ int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *pr
 // Add a single node to all indices its properties match
 void GraphContext_AddNodeToIndices(GraphContext *gc, LabelStore *store, Node *n);
 
+// Remove a single node property from an index and re-insert with new value
 void GraphContext_UpdateNodeIndices(GraphContext *gc, NodeID id, EntityProperty *prop, SIValue *newval);
 
 // Remove a single node from all indices that refer to it

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -23,6 +23,8 @@ typedef struct {
   LabelStore **relation_stores;    // Array of schemas for each relation type
   LabelStore **node_stores;        // Array of schemas for each node label 
 
+  // TODO These are only stored to simplify serialization, and require
+  // the addition of an ID member to the Index struct. Possibly have better options.
   unsigned int index_cap;          // Capacity of indices array
   unsigned int index_count;        // Number of indices
   Index **indices;                 // Array of all indices on label-property pairs

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -13,20 +13,11 @@ typedef struct {
   char *graph_name;                // String associated with graph
   Graph *g;                        // Container for all matrices and entity properties
 
-  unsigned int relation_cap;       // Capacity of relation LabelStore array
-  unsigned int relation_count;     // Number of relation tyes
-  unsigned int label_cap;          // Capacity of node LabelStore array
-  unsigned int label_count;        // Number of label matrices.
-
   LabelStore *relation_allstore;   // Schema for all relation types
   LabelStore *node_allstore;       // Schema for all/unspecified node labels
   LabelStore **relation_stores;    // Array of schemas for each relation type
   LabelStore **node_stores;        // Array of schemas for each node label 
 
-  // TODO These are only stored to simplify serialization, and require
-  // the addition of an ID member to the Index struct. Possibly have better options.
-  unsigned int index_cap;          // Capacity of indices array
-  unsigned int index_count;        // Number of indices
   Index **indices;                 // Array of all indices on label-property pairs
 } GraphContext;
 

--- a/src/graph/serializers/graphcontext_type.c
+++ b/src/graph/serializers/graphcontext_type.c
@@ -18,10 +18,10 @@ RedisModuleType *GraphContextRedisModuleType;
 
 void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
   /* Format:
-   * graph name   
+   * graph name
    * #label stores
    * label allstore
-   * label store X #label stores   
+   * label store X #label stores
    * #relation stores
    * relation allstore
    * relation store X #relation
@@ -40,7 +40,7 @@ void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
 
   // Serialize label all store.
   RdbSaveStore(rdb, gc->node_allstore);
-  
+
   // Name of label X #label stores.
   for(int i = 0; i < label_count; i++) {
     LabelStore *s = gc->node_stores[i];
@@ -50,12 +50,12 @@ void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
   // #Relation stores.
   uint32_t relation_count = array_len(gc->relation_stores);
   RedisModule_SaveUnsigned(rdb, relation_count);
-  
+
   // Serialize relation all store.
   RdbSaveStore(rdb, gc->relation_allstore);
 
   // Name of relation X #relation.
-  for(uint32_t  i = 0; i < relation_count; i++) {
+  for(uint32_t i = 0; i < relation_count; i++) {
     LabelStore *s = gc->relation_stores[i];
     RdbSaveStore(rdb, s);
   }
@@ -69,7 +69,7 @@ void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
 
   // Serialize each index
   Index *idx;
-  for (uint32_t  i = 0; i < index_count; i ++) {
+  for (uint32_t i = 0; i < index_count; i ++) {
     idx = gc->indices[i];
     RedisModule_SaveStringBuffer(rdb, idx->label, strlen(idx->label) + 1);
     RedisModule_SaveStringBuffer(rdb, idx->property, strlen(idx->property) + 1);
@@ -78,13 +78,13 @@ void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
 
 void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
   /* Format:
-   * graph name   
+   * graph name
    * #label stores
    * label allstore
    * name of label X #label stores
    * #relation stores
    * relation allstore
-   * name of relation X #relation   
+   * name of relation X #relation
    * graph object
    * #indices
    * (index label, index property) X #indices

--- a/src/graph/serializers/graphcontext_type.c
+++ b/src/graph/serializers/graphcontext_type.c
@@ -9,6 +9,7 @@
 #include "graphcontext_type.h"
 #include "serialize_graph.h"
 #include "serialize_store.h"
+#include "../../util/arr.h"
 #include "../../util/rmalloc.h"
 #include "../../version.h"
 
@@ -34,25 +35,27 @@ void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
   RedisModule_SaveStringBuffer(rdb, gc->graph_name, strlen(gc->graph_name) + 1);
 
   // #Label stores.
-  RedisModule_SaveUnsigned(rdb, gc->label_count);
+  uint32_t label_count = array_len(gc->node_stores);
+  RedisModule_SaveUnsigned(rdb, label_count);
 
   // Serialize label all store.
   RdbSaveStore(rdb, gc->node_allstore);
   
   // Name of label X #label stores.
-  for(int i = 0; i < gc->label_count; i++) {
+  for(int i = 0; i < label_count; i++) {
     LabelStore *s = gc->node_stores[i];
     RdbSaveStore(rdb, s);
   }
 
   // #Relation stores.
-  RedisModule_SaveUnsigned(rdb, gc->relation_count);
+  uint32_t relation_count = array_len(gc->relation_stores);
+  RedisModule_SaveUnsigned(rdb, relation_count);
   
   // Serialize relation all store.
   RdbSaveStore(rdb, gc->relation_allstore);
 
   // Name of relation X #relation.
-  for(int i = 0; i < gc->relation_count; i++) {
+  for(uint32_t  i = 0; i < relation_count; i++) {
     LabelStore *s = gc->relation_stores[i];
     RdbSaveStore(rdb, s);
   }
@@ -61,11 +64,12 @@ void GraphContextType_RdbSave(RedisModuleIO *rdb, void *value) {
   RdbSaveGraph(rdb, gc->g);
 
   // #Indices.
-  RedisModule_SaveUnsigned(rdb, gc->index_count);
+  uint32_t index_count = array_len(gc->indices);
+  RedisModule_SaveUnsigned(rdb, index_count);
 
   // Serialize each index
   Index *idx;
-  for (int i = 0; i < gc->index_count; i ++) {
+  for (uint32_t  i = 0; i < index_count; i ++) {
     idx = gc->indices[i];
     RedisModule_SaveStringBuffer(rdb, idx->label, strlen(idx->label) + 1);
     RedisModule_SaveStringBuffer(rdb, idx->property, strlen(idx->property) + 1);
@@ -94,11 +98,6 @@ void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
 
   GraphContext *gc = rm_malloc(sizeof(GraphContext));
 
-  // Initialize the generic label and relation stores
-  gc->node_stores = NULL;
-  gc->relation_stores = NULL;
-  gc->indices = NULL;    
-
   // Graph name
   // Duplicating string so that it can be safely freed if GraphContext
   // is deleted.
@@ -106,30 +105,29 @@ void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
   gc->g = Graph_New(GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
 
   // #Label stores
-  gc->label_count = RedisModule_LoadUnsigned(rdb);
-  gc->label_cap = gc->label_count;
+  uint32_t label_count = RedisModule_LoadUnsigned(rdb);
 
   // label all store.
   gc->node_allstore = RdbLoadStore(rdb);
 
   // Retrieve each label store
-  gc->node_stores = rm_malloc((gc->label_count) * sizeof(LabelStore*));
-  for (int i = 0; i < gc->label_count; i ++) {
-    gc->node_stores[i] = RdbLoadStore(rdb);
+  gc->node_stores = array_new(LabelStore*, label_count);
+  for (uint32_t i = 0; i < label_count; i ++) {
+    array_append(gc->node_stores, RdbLoadStore(rdb));
     Graph_AddLabel(gc->g);
   }
 
   // #Relation stores
-  gc->relation_count = RedisModule_LoadUnsigned(rdb);
-  gc->relation_cap = gc->relation_count;
+  uint32_t relation_count = RedisModule_LoadUnsigned(rdb);
 
   // Relation all store.
   gc->relation_allstore = RdbLoadStore(rdb);
 
   // Retrieve each relation store
-  gc->relation_stores = rm_malloc((gc->relation_count) * sizeof(LabelStore*));
-  for (int i = 0; i < gc->relation_count; i ++) {
-    gc->relation_stores[i] = RdbLoadStore(rdb);
+  gc->relation_stores = array_new(LabelStore*, relation_count);
+
+  for (uint32_t i = 0; i < relation_count; i ++) {
+    array_append(gc->relation_stores, RdbLoadStore(rdb));
     Graph_AddRelationType(gc->g);
   }
 
@@ -138,11 +136,9 @@ void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
 
   // #Indices
   // (index label, index property) X #indices
-  uint64_t index_count = RedisModule_LoadUnsigned(rdb);
-  gc->index_count = 0;
-  gc->index_cap = index_count;
-  gc->indices = rm_malloc(gc->index_cap * sizeof(Index*));
-  for (int i = 0; i < index_count; i ++) {
+  uint32_t index_count = RedisModule_LoadUnsigned(rdb);
+  gc->indices = array_new(Index*, index_count);
+  for (uint32_t i = 0; i < index_count; i ++) {
     const char *label = RedisModule_LoadStringBuffer(rdb, NULL);
     const char *property = RedisModule_LoadStringBuffer(rdb, NULL);
     GraphContext_AddIndex(gc, label, property);
@@ -174,3 +170,4 @@ int GraphContextType_Register(RedisModuleCtx *ctx) {
   }
   return REDISMODULE_OK;
 }
+

--- a/src/graph/serializers/serialize_graph.c
+++ b/src/graph/serializers/serialize_graph.c
@@ -175,7 +175,7 @@ void _RdbSaveNodes(RedisModuleIO *rdb, const Graph *g) {
         RedisModule_SaveUnsigned(rdb, 1);
 
         // (labels) X M
-        int l = Graph_GetNodeLabel(g, e->id);
+        int l = Graph_GetLabelID(g, e->id);
         RedisModule_SaveUnsigned(rdb, l);
         
         // properties N

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -8,8 +8,9 @@
 #include "index.h"
 #include "../util/rmalloc.h"
 
-/* Memory management and comparator functions that get attached to
- * string and numeric skiplists as function pointers. */
+//------------------------------------------------------------------------------
+// Function pointers for skiplist routines
+//------------------------------------------------------------------------------
 int compareNodes(NodeID a, NodeID b) {
   return a - b;
 }
@@ -36,6 +37,9 @@ void freeKey(SIValue *key) {
   rm_free(key);
 }
 
+//------------------------------------------------------------------------------
+// Index creation functions
+//------------------------------------------------------------------------------
 void initializeSkiplists(Index *index) {
   index->string_sl = skiplistCreate(compareStrings, compareNodes, cloneKey, freeKey);
   index->numeric_sl = skiplistCreate(compareNumerics, compareNodes, cloneKey, freeKey);
@@ -97,6 +101,23 @@ Index* Index_Create(Graph *g, int label_id, const char *label, const char *prop_
 
   return index;
 }
+
+//------------------------------------------------------------------------------
+// Index updates
+//------------------------------------------------------------------------------
+
+void Index_DeleteNode(Index *idx, NodeID node, SIValue *val) {
+  skiplist *sl = val->type == T_STRING ? idx->string_sl : idx->numeric_sl;
+  skiplistDelete(sl, val, &node);
+}
+ void Index_InsertNode(Index *idx, NodeID node, SIValue *val) {
+  skiplist *sl = val->type == T_STRING ? idx->string_sl : idx->numeric_sl;
+  skiplistInsert(sl, val, node);
+}
+
+//------------------------------------------------------------------------------
+// Index iterator functions
+//------------------------------------------------------------------------------
 
 /* Generate an iterator with no lower or upper bound. */
 IndexIter* IndexIter_Create(Index *idx, SIType type) {

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -36,6 +36,10 @@ typedef struct {
  * on these entities can use expedited scan logic. */
 Index* Index_Create(Graph *g, int label_id, const char *label, const char *prop_str);
 
+void Index_DeleteNode(Index *idx, NodeID node, SIValue *val);
+
+void Index_InsertNode(Index *idx, NodeID node, SIValue *val);
+
 /* Build a new iterator to traverse all indexed values of the specified type. */
 IndexIter* IndexIter_Create(Index *idx, SIType type);
 

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -26,7 +26,6 @@ typedef skiplistIterator IndexIter;
  * When building Index Scan operations, the types of values described by filters will
  * specify which skiplist should be traversed. */
 typedef struct {
-  int id; // Only required for compacting indices array
   char *label;
   char *property;
   skiplist *string_sl;

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -36,8 +36,10 @@ typedef struct {
  * on these entities can use expedited scan logic. */
 Index* Index_Create(Graph *g, int label_id, const char *label, const char *prop_str);
 
+/* Delete a single entity from an index if it is present. */
 void Index_DeleteNode(Index *idx, NodeID node, SIValue *val);
 
+/* Insert a single entity into an index. */
 void Index_InsertNode(Index *idx, NodeID node, SIValue *val);
 
 /* Build a new iterator to traverse all indexed values of the specified type. */

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -26,6 +26,7 @@ typedef skiplistIterator IndexIter;
  * When building Index Scan operations, the types of values described by filters will
  * specify which skiplist should be traversed. */
 typedef struct {
+  int id; // Only required for compacting indices array
   char *label;
   char *property;
   skiplist *string_sl;

--- a/src/stores/store.c
+++ b/src/stores/store.c
@@ -22,8 +22,17 @@ LabelStore* LabelStore_New(const char *label, int id) {
 void LabelStore_UpdateSchema(LabelStore *store, int prop_count, char **properties) {
     for(int idx = 0; idx < prop_count; idx++) {
         char *property = properties[idx];
-        TrieMap_Add(store->properties, property, strlen(property), NULL, NULL);
+        // Use TrieMap_NOP_REPLACE so we don't overwrite possible index values
+        TrieMap_Add(store->properties, property, strlen(property), NULL, TrieMap_NOP_REPLACE);
     }
+}
+
+void LabelStore_AssignValue(LabelStore *store, char *property, void *val) {
+    TrieMap_Add(store->properties, property, strlen(property), val, TrieMap_DONT_CARE_REPLACE);
+}
+
+void* LabelStore_RetrieveValue(LabelStore *store, char *property) {
+    return TrieMap_Find(store->properties, property, strlen(property));
 }
 
 void LabelStore_Free(LabelStore *store) {
@@ -31,3 +40,4 @@ void LabelStore_Free(LabelStore *store) {
     if(store->label) rm_free(store->label);
     rm_free(store);
 }
+

--- a/src/stores/store.h
+++ b/src/stores/store.h
@@ -29,7 +29,13 @@ LabelStore* LabelStore_New(const char *label, int id);
 /* Update store schema with given properties. */
 void LabelStore_UpdateSchema(LabelStore *store, int prop_count, char **properties);
 
+/* Attach a pointer value to a property key. */
+void LabelStore_AssignValue(LabelStore *store, char *property, void *val);
+
+void* LabelStore_RetrieveValue(LabelStore *store, char *property);
+
 /* Free store. */
 void LabelStore_Free(LabelStore *store);
 
 #endif /* __LABEL_STORE_H__ */
+

--- a/src/util/arr.h
+++ b/src/util/arr.h
@@ -111,7 +111,6 @@ static inline uint32_t array_len(array_t arr) {
 
 static inline void *array_trimm(array_t arr, uint32_t len, uint32_t cap) {
   array_hdr_t *arr_hdr = array_hdr(arr);
-  assert(len >= 0 && "trimming len is negative");
   assert((cap == -1 || cap > 0) && "trimming capacity is illegal");
   assert((cap == -1 || cap >= len) && "trimming len is greater then capacity");
   assert((len <= arr_hdr->len) && "trimming len is greater then current len");

--- a/src/util/skiplist.c
+++ b/src/util/skiplist.c
@@ -424,6 +424,10 @@ void _update_upper_bound(skiplistIterator *iter, skiplistKey bound, int exclusiv
  * Update skiplist bounds according to specified op - returns 1 if filter was applicable
  * (regardless of whether it improves upon original bound) and 0 otherwise. */
 bool skiplistIter_UpdateBound(skiplistIterator *iter, skiplistKey bound, int op) {
+  /* If the iterator is already depleted, the resulting index scan will return nothing, which
+   * is a valid result (contradictory filters, specifying incorrect property types). */
+  if (iter->current == NULL) return 1;
+
   switch(op) {
     case EQ:
       /* EQ should set an inclusive lower and upper bound on the same key, unless

--- a/src/util/triemap/triemap.c
+++ b/src/util/triemap/triemap.c
@@ -492,6 +492,11 @@ void* TrieMap_DONT_CARE_REPLACE(void *oldval, void *newval) {
   return newval;
 }
 
+void* TrieMap_NOP_REPLACE(void *oldval, void *newval) {
+  (void)(newval);
+  return oldval;
+}
+
 void TrieMapNode_Free(TrieMapNode *n, void (*freeCB)(void *)) {
   for (tm_len_t i = 0; i < n->numChildren; i++) {
     TrieMapNode *child = __trieMapNode_children(n)[i];

--- a/src/util/triemap/triemap.h
+++ b/src/util/triemap/triemap.h
@@ -51,7 +51,7 @@ typedef void *(*TrieMapReplaceFunc)(void *oldval, void *newval);
 /* Add a new string to a trie. Returns 1 if the key is new to the trie or 0 if
 * it already existed.
 *
-* If value is given, it is saved as a pyaload inside the trie node.
+* If value is given, it is saved as a payload inside the trie node.
 * If the key already exists, we replace the old value with the new value, using
 * free() to free the old value.
 *
@@ -80,8 +80,11 @@ int TrieMap_Delete(TrieMap *t, char *str, tm_len_t len, void (*freeCB)(void *));
 /* Fake free callback which does absolutely nothing. */
 void TrieMap_NOP_CB(void *p);
 
-/* Fake replace callback replaces the newval with the old one. */
+/* Replace callback that replaces the oldval with the new one. */
 void* TrieMap_DONT_CARE_REPLACE(void *oldval, void *newval);
+
+/* Fake replace callback that does not overwrite old value. */
+void* TrieMap_NOP_REPLACE(void *oldval, void *newval);
 
 /* Free the trie's root and all its children recursively. If freeCB is given, we
  * call it to free individual payload values. If not, free() is used instead. */

--- a/tests/flow/test_index.py
+++ b/tests/flow/test_index.py
@@ -1,0 +1,156 @@
+import os
+import sys
+import unittest
+import random
+import string
+from redisgraph import Graph, Node, Edge
+
+from .disposableredis import DisposableRedis
+from base import FlowTestsBase
+
+redis_graph = None
+labels = ["label_a", "label_b"]
+fields = ['unique', 'group', 'doubleval', 'intval', 'stringval']
+groups = ["Group A", "Group B", "Group C","Group D", "Group E"]
+node_ctr = 0
+
+def redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class IndexUpdatesFlowTest(FlowTestsBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print "IndexUpdatesFlowTest"
+        global redis_graph
+        cls.r = redis()
+        cls.r.start()
+        redis_con = cls.r.client()
+        redis_graph = Graph("index_test", redis_con)
+        cls.populate_graph()
+        cls.build_indices()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+
+    @classmethod
+    def new_node(self):
+        return Node(label = labels[node_ctr % 2],
+                    properties = {'unique': node_ctr,
+                                  'group': random.choice(groups),
+                                  'doubleval': round(random.uniform(-1, 1), 2),
+                                  'intval': random.randint(1, 10000),
+                                  'stringval': ''.join(random.choice(string.lowercase) for x in range(6))})
+    @classmethod
+    def populate_graph(self):
+        global node_ctr
+        for i in range(1000):
+            node = self.new_node()
+            redis_graph.add_node(node)
+            node_ctr += 1
+        redis_graph.commit()
+    
+    @classmethod
+    def build_indices(self):
+        for field in fields:
+            redis_graph.redis_con.execute_command("GRAPH.QUERY", "index_test", "CREATE INDEX ON :label_a(%s)" % (field))
+            redis_graph.redis_con.execute_command("GRAPH.QUERY", "index_test", "CREATE INDEX ON :label_b(%s)" % (field))
+
+    # Validate that all properties are indexed
+    def validate_indexed(self):
+        for field in fields:
+            resp = redis_graph.execution_plan("""MATCH (a:label_a) WHERE a.%s > 0 RETURN a""" % (field))
+            self.assertIn('Index Scan', resp)
+
+    # So long as 'unique' is not modified, label_a.unique will always be even and label_b.unique will always be odd
+    def validate_unique(self):
+        result = redis_graph.query("MATCH (a:label_a) RETURN a.unique")
+        # Remove the header
+        result.result_set.pop(0)
+        for val in result.result_set:
+            assert(int(float(val[0])) % 2 == 0)
+
+        result = redis_graph.query("MATCH (b:label_b) RETURN b.unique")
+        # Remove the header
+        result.result_set.pop(0)
+        for val in result.result_set:
+            assert(int(float(val[0])) % 2 == 1)
+
+    # The index scan ought to return identical results to a label scan over the same range of values.
+    def validate_doubleval(self):
+        for label in ["label_a", "label_b"]:
+            resp = redis_graph.execution_plan("""MATCH (a:%s) WHERE a.doubleval < 100 RETURN a.doubleval ORDER BY a.doubleval""" % (label))
+            self.assertIn('Index Scan', resp)
+            indexed_result = redis_graph.query("""MATCH (a:%s) WHERE a.doubleval < 100 RETURN a.doubleval ORDER BY a.doubleval""" % (label))
+            scan_result = redis_graph.query("""MATCH (a:%s) RETURN a.doubleval ORDER BY a.doubleval""" % (label))
+
+            self.assertEqual(len(indexed_result.result_set), len(scan_result.result_set))
+            # Collect any elements between the two result sets that fail a string comparison
+            # so that we may compare them as doubles (specifically, -0 and 0 should be considered equal)
+            differences = [[i[0], j[0]] for i, j in zip(indexed_result.result_set, scan_result.result_set) if i != j]
+            for pair in differences:
+                self.assertEqual(float(pair[0]), float(pair[1]))
+
+    # The intval property can be assessed similar to doubleval, but the result sets should be identical
+    def validate_intval(self):
+        for label in ["label_a", "label_b"]:
+            resp = redis_graph.execution_plan("""MATCH (a:%s) WHERE a.intval > 0 RETURN a.intval ORDER BY a.intval""" % (label))
+            self.assertIn('Index Scan', resp)
+            indexed_result = redis_graph.query("""MATCH (a:%s) WHERE a.intval > 0 RETURN a.intval ORDER BY a.intval""" % (label))
+            scan_result = redis_graph.query("""MATCH (a:%s) RETURN a.intval ORDER BY a.intval""" % (label))
+
+            self.assertEqual(indexed_result.result_set, scan_result.result_set)
+
+
+    # Validate a series of premises to ensure that the graph has not been modified unexpectedly
+    def validate_state(self):
+        self.validate_unique()
+        self.validate_indexed()
+        self.validate_doubleval()
+        self.validate_intval()
+
+    # Modify a property, triggering updates to all nodes in two indices
+    def test01_full_property_update(self):
+        result = redis_graph.query("MATCH (a) SET a.doubleval = a.doubleval + %f" % (round(random.uniform(-1, 1), 2)))
+        assert(result.properties_set == 1000)
+        # Verify that index scans still function and return correctly
+        self.validate_state()
+
+    # Modify a property, triggering updates to a subset of nodes in two indices
+    def test02_partial_property_update(self):
+        redis_graph.query("MATCH (a) WHERE a.doubleval > 0 SET a.doubleval = a.doubleval + %f" % (round(random.uniform(-1, 1), 2)))
+        # Verify that index scans still function and return correctly
+        self.validate_state()
+
+    #  Add 100 randomized nodes and validate indices
+    def test03_node_creation(self):
+        # Reset nodes in the Graph object so that we won't double-commit the originals
+        redis_graph.nodes = {}
+        global node_ctr
+        for i in range(100):
+            node = self.new_node()
+            redis_graph.add_node(node)
+            node_ctr += 1
+        redis_graph.commit()
+        self.validate_state()
+
+    # Delete every other node in first 100 and validate indices
+    def test04_node_deletion(self):
+        # Reset nodes in the Graph object so that we won't double-commit the originals
+        redis_graph.nodes = {}
+        global node_ctr
+        # Delete nodes one at a time
+        for i in range(0, 100, 2):
+            result = redis_graph.query("MATCH (a) WHERE ID(a) = %d DELETE a" % (i))
+            assert(result.nodes_deleted == 1)
+            node_ctr -= 1
+        self.validate_state()
+
+        # Delete all nodes matching a filter
+        result = redis_graph.query("MATCH (a:label_a) WHERE a.group = 'Group A' DELETE a")
+        assert(result.nodes_deleted > 0)
+        self.validate_state()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -1,0 +1,125 @@
+import os
+import sys
+import unittest
+from redisgraph import Graph, Node, Edge
+
+# import redis
+from .disposableredis import DisposableRedis
+
+from base import FlowTestsBase
+
+redis_con = None
+GRAPH_NAME = "G"
+redis_graph = None
+people = ["Roi", "Alon", "Ailon", "Boaz", "Tal", "Omri", "Ori"]
+countries = ["Israel", "USA", "Japan", "United Kingdom"]
+visits = [("Roi", "USA"), ("Alon", "Israel"), ("Ailon", "Japan"), ("Boaz", "United Kingdom")]
+
+def redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class GraphPersistency(FlowTestsBase):
+    @classmethod
+    def setUpClass(cls):
+        print "GraphPersistency"
+        global redis_graph
+        global redis_con
+        cls.r = redis()
+        cls.r.start()
+        redis_con = cls.r.client()
+        redis_graph = Graph(GRAPH_NAME, redis_con)
+
+        # redis_con = redis.Redis()
+        # redis_graph = Graph("G", redis_con)
+
+        cls.populate_graph()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+        # pass
+
+    @classmethod
+    def populate_graph(cls):
+        global redis_graph
+
+        if not redis_con.exists(GRAPH_NAME):
+            personNodes = {}
+            countryNodes = {}
+            # Create entities
+            
+            for p in people:
+                person = Node(label="person", properties={"name": p})
+                redis_graph.add_node(person)
+                personNodes[p] = person
+            
+            for p in countries:
+                country = Node(label="country", properties={"name": p})
+                redis_graph.add_node(country)
+                countryNodes[p] = country
+            
+            for v in visits:
+                person = v[0]
+                country = v[1]
+                edge = Edge(personNodes[person], 'visit', countryNodes[country], properties={'purpose': 'pleasure'})
+                redis_graph.add_edge(edge)
+
+            redis_graph.commit()
+
+            # Delete nodes, to introduce deleted item within our datablock
+            query = """MATCH (n:person) WHERE n.name = 'Roi' or n.name = 'Ailon' DELETE n"""
+            redis_graph.query(query)
+
+            query = """MATCH (n:country) WHERE n.name = 'USA' DELETE n"""
+            redis_graph.query(query)
+
+            # Create index.
+            actual_result = redis_con.execute_command("GRAPH.QUERY", GRAPH_NAME, "CREATE INDEX ON :person(name)")
+            actual_result = redis_con.execute_command("GRAPH.QUERY", GRAPH_NAME, "CREATE INDEX ON :country(name)")
+
+    # Connect a single node to all other nodes.
+    def test01_save_load_rdb(self):
+        pass
+        for i in range(2):
+            if i == 1:
+                # Save RDB & Load from RDB
+                redis_con.execute_command("DEBUG", "RELOAD")
+
+            # Verify
+            # Expecting 5 person entities.
+            query = """MATCH (p:person) RETURN COUNT(p)"""
+            actual_result = redis_graph.query(query)
+            nodeCount = int(float(actual_result.result_set[1][0]))
+            assert(nodeCount == 5)
+
+            query = """MATCH (p:person) WHERE p.name='Alon' RETURN COUNT(p)"""
+            actual_result = redis_graph.query(query)
+            nodeCount = int(float(actual_result.result_set[1][0]))
+            assert(nodeCount == 1)
+
+            # Expecting 3 country entities.
+            query = """MATCH (c:country) RETURN COUNT(c)"""
+            actual_result = redis_graph.query(query)
+            nodeCount = int(float(actual_result.result_set[1][0]))
+            assert(nodeCount == 3)
+
+            query = """MATCH (c:country) WHERE c.name = 'Israel' RETURN COUNT(c)"""
+            actual_result = redis_graph.query(query)
+            nodeCount = int(float(actual_result.result_set[1][0]))
+            assert(nodeCount == 1)
+
+            # Expecting 2 visit edges.
+            query = """MATCH (n:person)-[e:visit]->(c:country) WHERE e.purpose='pleasure' RETURN COUNT(e)"""
+            actual_result = redis_graph.query(query)        
+            edgeCount = int(float(actual_result.result_set[1][0]))
+            assert(edgeCount == 2)
+
+            # Verify indices exists.
+            actual_result = redis_con.execute_command("GRAPH.EXPLAIN", "G", "match (n:person) where n.name = 'Roi' RETURN n")
+            assert("Index Scan" in actual_result)
+
+            actual_result = redis_con.execute_command("GRAPH.EXPLAIN", "G", "match (n:country) where n.name = 'Israel' RETURN n")
+            assert("Index Scan" in actual_result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -271,9 +271,6 @@ void benchmark_edge_creation_with_relationships()
     float threshold = 0.002;
     int edge_count = 1000000 * 1.10;
     int node_count = 1000000;
-    // Unit tests cannot realloc the Graph relation and label arrays
-    // (as that is managed by the GraphContext).
-    // As such, this value cannot exceed GRAPH_DEFAULT_RELATION_CAP, currently 16.
     int relation_count = 3;
     EdgeDesc connections[edge_count];
     Node node;


### PR DESCRIPTION
LabelStore triemaps now hold pointers to indices when available.
CREATE, SET, and DELETE operations appropriately modify indices.