### PR TITLE
Don't execute queries from Lua or MULTI/EXEC blocks

### DIFF
--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -81,6 +81,13 @@ cleanup:
 int MGraph_Delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) return RedisModule_WrongArity(ctx);
 
+    // Return immediately if invocation context is Lua or a MULTI/EXEC block
+    int flags = RedisModule_GetContextFlags(ctx);
+    if (flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA)) {
+        RedisModule_ReplyWithError(ctx, "RedisGraph commands may not be called from non-blocking contexts.");
+        return REDISMODULE_OK;
+    }
+
     // Construct delete operation context.
     RedisModuleString *graph_name = argv[1];
     RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -18,6 +18,13 @@
 int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc < 3) return RedisModule_WrongArity(ctx);
 
+    // Return immediately if invocation context is Lua or a MULTI/EXEC block
+    int flags = RedisModule_GetContextFlags(ctx);
+    if (flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA)) {
+        RedisModule_ReplyWithError(ctx, "RedisGraph commands may not be called from non-blocking contexts.");
+        return REDISMODULE_OK;
+    }
+
     const char *query = RedisModule_StringPtrLen(argv[2], NULL);
 
     /* Parse query, get AST. */

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -126,6 +126,13 @@ int MGraph_Query(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     double tic[2];
     if (argc < 3) return RedisModule_WrongArity(ctx);
 
+    // Return immediately if invocation context is Lua or a MULTI/EXEC block
+    int flags = RedisModule_GetContextFlags(ctx);
+    if (flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA)) {
+        RedisModule_ReplyWithError(ctx, "RedisGraph commands may not be called from non-blocking contexts.");
+        return REDISMODULE_OK;
+    }
+
     simple_tic(tic);
 
     // Parse AST.


### PR DESCRIPTION
This PR is currently for conversational purposes. If we think this is a required change, it must be added to `cmd_delete` and `cmd_bulk_insert`.

See RED-23856.

This is a rather interesting issue! When `RedisModule_BlockClient` is called from Lua or MULTI/EXEC, an error is queued and the internal `bc->client` is set to NULL. However, we can still call `RedisModule_GetThreadSafeContext` on that blocked client, which overwrites `bc->client` with a fake (non-connected) client.
The module actually performs perfectly normally, including keyspace updates, except the Redis-level replies no longer reach the user.

Should we consider this a Redis bug? The `unstable` branch exhibits the same behavior. Are we actually allowed to operate in non-blocking contexts, and just not reply?