### PR TITLE
Respect Cypher specifications for orderability and comparability

### DIFF
--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -128,7 +128,7 @@ int __agg_maxStep(AggCtx *ctx, SIValue *argv, int argc) {
         return AGG_OK;
     }
 
-    if(SIValue_Compare(ac->max, argv[0]) < 0) {
+    if(SIValue_Order(ac->max, argv[0]) < 0) {
         ac->max = argv[0];
     }
 
@@ -169,7 +169,7 @@ int __agg_minStep(AggCtx *ctx, SIValue *argv, int argc) {
         return AGG_OK;
     }
 
-    if(SIValue_Compare(ac->min, argv[0]) > 0) {
+    if(SIValue_Order(ac->min, argv[0]) > 0) {
         ac->min = argv[0];
     }
 

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -97,12 +97,9 @@ FT_FilterNode* BuildFiltersTree(const AST_FilterNode *root) {
 /* Applies a single filter to a single result.
  * Compares given values, tests if values maintain desired relation (op) */
 int _applyFilter(SIValue* aVal, SIValue* bVal, int op) {
-
-    /* Always return false if values are not of comparable types. */
-    if (!SI_COMPARABLE(*aVal, *bVal)) return 0;
-
-    /* TODO Consider updating all logic around comparison routines */
     int rel = SIValue_Compare(*aVal, *bVal);
+    /* Always return false if values are not of comparable types. */
+    if (rel == DISJOINT) return 0;
 
     switch(op) {
         case EQ:

--- a/src/resultset/resultset_record.c
+++ b/src/resultset/resultset_record.c
@@ -59,7 +59,7 @@ int ResultSetRecord_Compare(const ResultSetRecord *A, const ResultSetRecord *B, 
         int index = compareIndices[i];
         a = A->values[index];
         b = B->values[index];
-        int relation = SIValue_Compare(a, b);
+        int relation = SIValue_Order(a, b);
         if(relation) return relation;
     }
 

--- a/src/value.h
+++ b/src/value.h
@@ -16,7 +16,7 @@
  *
  * The order of these values is significant, as the delta between values of
  * differing types is used to maintain the Cypher-defined global sort order
- * in the SIValue_Compare routine. */
+ * in the SIValue_Order routine. */
 typedef enum {
   T_NULL = 0,
   T_STRING = 0x001,
@@ -48,6 +48,8 @@ typedef enum {
  * This is necessary to construct safe integer returns when the delta between
  * two double values is < 1.0 (and would thus be rounded to 0). */
 #define COMPARE_RETVAL(a) ((a) > 0) - ((a) < 0)
+
+#define DISJOINT INT_MAX
 
 typedef struct {
   union {
@@ -100,10 +102,14 @@ size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count);
 /* Concats strings as a comma separated string. */
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *buf, size_t buf_len);
 
-/* Compares two SIValues and returns a value similar to strcmp.
- * If the values are not both strings or both numerics, the return value reflects
- * Cypher's orderability constraint, where string > number > NULL. */
+/* Compares two SIValues and returns a value similar to strcmp, or
+ * the macro DISJOINT if the values were not of comparable types. */
 int SIValue_Compare(SIValue a, SIValue b);
+
+/* Return a strcmp-style integer value indicating which value is greater according
+ * to Cypher's comparability property if applicable, and its orderability property if not.
+ * Under Cypher's orderability, where string < boolean < numeric < NULL. */
+int SIValue_Order(const SIValue a, const SIValue b);
 
 void SIValue_Print(FILE *outstream, SIValue *v);
 

--- a/tests/flow/test_value_comparisons.py
+++ b/tests/flow/test_value_comparisons.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import unittest
+from redisgraph import Graph, Node, Edge
+
+# import redis
+from .disposableredis import DisposableRedis
+
+from base import FlowTestsBase
+
+redis_graph = None
+
+values = ["str1", "str2", False, True, 5, 10.5]
+
+def redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class ValueComparisonTest(FlowTestsBase):
+    @classmethod
+    def setUpClass(cls):
+        print "ValueComparisonTest"
+        global redis_graph
+        cls.r = redis()
+        cls.r.start()
+        redis_con = cls.r.client()
+        redis_graph = Graph("G", redis_con)
+
+        cls.populate_graph()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+        # pass
+
+    @classmethod
+    def populate_graph(cls):
+        redis_graph
+
+        for v in values:
+            node = Node(label="value", properties={"val": v})
+            redis_graph.add_node(node)
+
+        # Add an additional node with no properties
+        redis_graph.add_node(Node(label="value"))
+
+        redis_graph.commit()
+
+    # Verify the ordering of values that can and cannot be directly compared
+    def test_orderability(self):
+        query = """MATCH (v:value) RETURN v ORDER BY v.val"""
+        actual_result = redis_graph.query(query)
+        expected = [['str1'],
+                    ['str2'],
+                    ['false'],
+                    ['true'],
+                    ['5.000000'],
+                    ['10.500000'],
+                    ['NULL']]
+        assert(actual_result.result_set[1:] == expected)
+
+        # Expect the results to appear in reverse when using descending order
+        query = """MATCH (v:value) RETURN v ORDER BY v.val DESC"""
+        actual_result = redis_graph.query(query)
+        assert(actual_result.result_set[1:] == expected[::-1])
+
+    # From the Cypher specification:
+    # "In a mixed set, any numeric value is always considered to be higher than any string value"
+    def test_mixed_type_min(self):
+        query = """MATCH (v:value) RETURN MIN(v.val)"""
+        actual_result = redis_graph.query(query)
+        assert(actual_result.result_set[1][0] == 'str1')
+
+    def test_mixed_type_max(self):
+        query = """MATCH (v:value) RETURN MAX(v.val)"""
+        actual_result = redis_graph.query(query)
+        assert(actual_result.result_set[1][0] == '10.500000')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This PR resolves all the issues I could think of with respect to comparability and ordering, but I admit that it does so because I reversed my thinking on what the strcmp-style return should be for disjoint types again. I'm really pretty sure this matches that format.

I've wanted to separate comparability and orderability logic for a while, so this PR still seems worthwhile.