### PR TITLE
Allow serialization of NULL-valued properties

### DIFF
--- a/src/graph/serializers/serialize_graph.c
+++ b/src/graph/serializers/serialize_graph.c
@@ -57,6 +57,8 @@ SIValue _RdbLoadSIValue(RedisModuleIO *rdb) {
         return SI_DoubleVal(RedisModule_LoadDouble(rdb));
     } else if (t == T_BOOL) {
         return SI_BoolVal(RedisModule_LoadUnsigned(rdb));
+    } else if (t == T_NULL) {
+        return SI_NullVal();
     } else {
         char *strVal = RedisModule_LoadStringBuffer(rdb, NULL);
         // Transfer ownership of the heap-allocated strVal to the
@@ -153,6 +155,8 @@ void _RdbSaveSIValue(RedisModuleIO *rdb, const SIValue *v) {
         RedisModule_SaveDouble(rdb, v->doubleval);
     } else if (v->type == T_BOOL) {
         RedisModule_SaveUnsigned(rdb, v->boolval);
+    } else if (v->type == T_NULL) {
+        return; // No data beyond the type needs to be encoded for a NULL value.
     } else if (v->type & SI_STRING) {
         RedisModule_SaveStringBuffer(rdb, v->stringval, strlen(v->stringval) + 1);
     } else {


### PR DESCRIPTION
Not having this already was an oversight, and causes serialization failures for some of Ariel's test files (as the bulk loader now supports NULL properties).

As a sidenote, we can't compare directly against NULL values, which I think we need to resolve:
```
12:22 $ redis-cli GRAPH.QUERY G "MATCH (a {primaryName: 'Gary Rosen'}) return a.primaryProfession ORDER BY a.primaryProfession"
1) 1) 1) "a.primaryProfession"
   2) 1) "actor"
   3) 1) "actor"
   4) 1) "producer"
   5) 1) "producer"
   6) 1) "writer"
   7) 1) "NULL"

12:22 $ redis-cli GRAPH.QUERY G "MATCH (a {primaryName: 'Gary Rosen'}) WHERE a.primaryProfession = NULL return a.primaryProfession ORDER BY a.primaryProfession"
1) 1) 1) "a.primaryProfession"

12:22 $ redis-cli GRAPH.QUERY G "MATCH (a {primaryName: 'Gary Rosen'}) WHERE a.primaryProfession != NULL return a.primaryProfession ORDER BY a.primaryProfession"
1) 1) 1) "a.primaryProfession"

```