### PR TITLE
traverse multiple nodes concurrently

### DIFF
--- a/src/execution_plan/ops/op_conditional_traverse.h
+++ b/src/execution_plan/ops/op_conditional_traverse.h
@@ -19,16 +19,19 @@ typedef struct {
     OpBase op;
     Graph *graph;
     AlgebraicExpression *algebraic_expression;
-    GrB_Matrix F;
-    GrB_Matrix M;
-    int *edgeRelationTypes; // One or more relation types.
-    int edgeRelationCount;  // length of edgeRelationTypes.
-    Edge *edges;
-    GxB_MatrixTupleIter *iter;
-    int srcNodeRecIdx;
-    int destNodeRecIdx;
-    int edgeRecIdx;
-    Record r;
+    GrB_Matrix F;               // Filter matrix.
+    GrB_Matrix M;               // Algebraic expression result.
+    int *edgeRelationTypes;     // One or more relation types.
+    int edgeRelationCount;      // length of edgeRelationTypes.
+    Edge *edges;                // Discovered edges.
+    GxB_MatrixTupleIter *iter;  // Iterator over M.
+    int srcNodeRecIdx;          // Index into record.
+    int destNodeRecIdx;         // Index into record.
+    int edgeRecIdx;             // Index into record.
+    int recordsCap;             // Max number of records to process.
+    int recordsLen;             // Number of records to process.
+    Record *records;            // Array of records.
+    Record r;                   // Current selected record.
 } CondTraverse;
 
 /* Creates a new Traverse operation */


### PR DESCRIPTION
Now that the execution plan can handle multiple records, we moved from a filter vector representing traversal from a single node to a filter matrix, representing multiple source nodes from which we perform traversal. first test see a ~X3 speed up.

the point to note is the need to keep matrix multiplication sparse, this was the main reason we've used a filter vector, now with a filter matrix we keep it to a decent size: MX16 at max, in the future we might want to be smarter about its dimension.