### PR TITLE
Store graph name string outside of Redis context

### DIFF
--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -33,6 +33,7 @@ void _MGraph_BulkInsert(void *args) {
 
     RedisModuleString **argv = context->argv + 1; // skip "GRAPH.BULK"
     RedisModuleString *rs_graph_name = *argv++;
+    const char *graphname = RedisModule_StringPtrLen(rs_graph_name, NULL);
     int argc = context->argc - 2; // skip "GRAPH.BULK [GRAPHNAME]"
     RedisModuleKey *key;
 
@@ -58,7 +59,6 @@ void _MGraph_BulkInsert(void *args) {
         // Verify that graph does not already exist.
         key = RedisModule_OpenKey(ctx, rs_graph_name, REDISMODULE_READ);
         if (key) {
-            const char *graphname = RedisModule_StringPtrLen(rs_graph_name, NULL);
             char *err;
             asprintf(&err, "Graph with name '%s' cannot be created, as Redis key '%s' already exists.", graphname, graphname); 
             RedisModule_ReplyWithError(ctx, err);
@@ -81,11 +81,11 @@ void _MGraph_BulkInsert(void *args) {
 
     if (initial_query) {
         // Create graph and initialize its data stores.
-        gc = GraphContext_New(ctx, rs_graph_name, nodes_in_query, relations_in_query);
+        gc = GraphContext_New(ctx, graphname, nodes_in_query, relations_in_query);
         assert(gc);
     } else {
         // Query did not start with a "BEGIN" token
-        gc = GraphContext_Retrieve(ctx, rs_graph_name);
+        gc = GraphContext_Retrieve(ctx, graphname);
         if (gc == NULL) {
             RedisModule_ReplyWithError(ctx, "Bulk insert query did not include a BEGIN token and graph was not found.");
             goto cleanup;

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -27,6 +27,7 @@ int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
+    const char *graphname = RedisModule_StringPtrLen(argv[1], NULL);
     const char *query = RedisModule_StringPtrLen(argv[2], NULL);
 
     /* Parse query, get AST. */
@@ -46,7 +47,7 @@ int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     // Retrieve the GraphContext and acquire a read lock.
     // RedisModule_ThreadSafeContextLock(ctx);
-    gc = GraphContext_Retrieve(ctx, argv[1]);
+    gc = GraphContext_Retrieve(ctx, graphname);
     // RedisModule_ThreadSafeContextUnlock(ctx);
     if(!gc) {
         RedisModule_ReplyWithError(ctx, "key doesn't contains a graph object.");

--- a/src/commands/cmd_query.h
+++ b/src/commands/cmd_query.h
@@ -17,8 +17,8 @@ extern threadpool _thpool;
 /* Query context, used for concurent query processing. */
 typedef struct {
     RedisModuleBlockedClient *bc;   // Blocked client.
-    AST* ast;                 // Parsed AST.
-    RedisModuleString *graphName;   // Graph ID.
+    AST *ast;                       // Parsed AST.
+    char *graphName;                // Graph ID.
     double tic[2];                  // timings.
 } QueryContext;
 

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -22,9 +22,9 @@ typedef struct {
 } GraphContext;
 
 /* GraphContext API */
-GraphContext* GraphContext_New(RedisModuleCtx *ctx, RedisModuleString *rs_name,
+GraphContext* GraphContext_New(RedisModuleCtx *ctx, const char *graphname,
                                size_t node_cap, size_t edge_cap);
-GraphContext* GraphContext_Retrieve(RedisModuleCtx *ctx, RedisModuleString *rs_graph_name);
+GraphContext* GraphContext_Retrieve(RedisModuleCtx *ctx, const char *graphname);
 
 // Retrives graph context from thread local storage.
 GraphContext* GraphContext_GetFromLTS();


### PR DESCRIPTION
I observed that race condition in unblockClient argv freeing again.

This solution is admittedly a bit silly, but I'm really disinclined to trust `RedisModuleCtx`-scoped memory at this point!