### PR TITLE
Don't install or check for OpenMP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEPS "python python-setuptools python-pip wget build-essential cmake m4"
 RUN set -ex;\
     deps="$DEPS";\
     apt-get update;\
-	apt-get install -y --no-install-recommends $deps;\
+    apt-get install -y --no-install-recommends $deps;\
     pip install rmtest;\
     pip install redisgraph;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ FROM redis:latest
 ENV LIBDIR /usr/lib/redis/modules
 WORKDIR /data
 RUN set -ex;\
-    apt-get update;\
-    apt-get install -y --no-install-recommends libgomp1;\
     mkdir -p "$LIBDIR";
 
 COPY --from=builder /redisgraph/src/redisgraph.so "$LIBDIR"

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ CFLAGS += $(DEBUGFLAGS)
 ifeq ($(uname_S),Linux)
 	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions -ldl -lpthread
 else
-	CFLAGS += -mmacosx-version-min=10.14 -Xpreprocessor
+	CFLAGS += -mmacosx-version-min=10.14
 	SHOBJ_LDFLAGS ?= -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -ldl -lpthread
 endif
 SHOBJ_LDFLAGS += $(LDFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,20 +17,10 @@ CFLAGS += $(DEBUGFLAGS)
 
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
-	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions -fopenmp -ldl -lpthread
+	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions -ldl -lpthread
 else
-	CFLAGS += -mmacosx-version-min=10.14 -Xpreprocessor -fopenmp
-	SHOBJ_LDFLAGS ?= -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -lomp -ldl -lpthread
-
-	# If we are using the Apple toolchain compiler, some extra work is required to validate dependencies.
-	compiler := $(findstring Apple LLVM,$(shell sh -c '$(CC) --version'))
-	ifneq (,$(compiler))
-	# Verify that the user has separately installed the OpenMP dependency.
-		openmp_support := $(shell sh -c 'brew ls --versions libomp || echo no_openmp')
-		ifeq ($(openmp_support), no_openmp)
-      $(error "Error: OpenMP is required for compilation. Install by running 'brew install libomp'.")
-		endif
-	endif
+	CFLAGS += -mmacosx-version-min=10.14 -Xpreprocessor
+	SHOBJ_LDFLAGS ?= -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -ldl -lpthread
 endif
 SHOBJ_LDFLAGS += $(LDFLAGS)
 

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -10,16 +10,6 @@ CPPFLAGS += -isystem $(GTEST_DIR)/include
 CXXFLAGS += -g -Wall -Wextra -pthread -std=c++11
 CXX_SUPPRESS = -Wno-sign-compare -Wno-format -Wno-write-strings
 
-uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-# Platform-specific compilation flags
-ifeq ($(uname_S),Linux)
-	CXXFLAGS += -fopenmp
-	LDFLAGS += -fopenmp
-else
-	CXXFLAGS += -Xpreprocessor -fopenmp
-	LDFLAGS += -lomp
-endif
-
 REDISGRAPH_CXX=$(QUIET_CXX)$(CXX)
 
 CCCOLOR="\033[34m"


### PR DESCRIPTION
My testing suggests that this is a safe change to make, and it entirely removes the module's dependency on OpenMP / libgomp:
before:
```
root@ecde5f7447d1:/# ldd redisgraph.so
        linux-vdso.so.1 (0x00007fff3b593000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f61a14cb000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f61a12ac000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f61a0ebb000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f61a0b1d000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f61a19d9000)
        libgomp.so.1 => not found
```
after:
```
root@5a8fc1694f6a:/# ldd graph.so
        linux-vdso.so.1 (0x00007ffe2fbed000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f18bc8d1000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f18bc6b2000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f18bc2c1000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f18bbf23000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f18bcddf000)
```

If you could checkout this branch to test it on OSX, I'd appreciate it! The steps I'd recommend:
```
brew uninstall --force libomp
cd deps/GraphBLAS
make clean
cd ../..
make clean && make
```
I don't expect CMake to complain, but let me know if it does.

I manufactured a race condition by simultaneously running:
`redis-benchmark -c 10 -e -n 10000000 "GRAPH.QUERY" "G" "CREATE (:node1{propname:'lllll'})-[:edge]->(:node2{otherprop:'EEE'})"`
and
`~/dev/redis/redis-base/src/redis-benchmark -c 10 -e -n 1000000 "GRAPH.QUERY" "G" "MATCH (N)-[*]->(P) RETURN N, P LIMIT 1000"`

This would pretty reliably crash before the OpenMP dependency was satisfied. If you choose to cancel and restart the benchmarks, you may encounter crashes on client unblocking (resolved by #322).