### PR TITLE
Type-safe numeric addition

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -315,23 +315,25 @@ void AR_EXP_Free(AR_ExpNode *root) {
 /* Mathematical functions - numeric */
 
 SIValue AR_ADD(SIValue *argv, int argc) {
-    SIValue result;
-    result = argv[0];
+    SIValue result = argv[0];
+    /* If the result is numeric, ensure that it is represented as a double. */
+    bool numeric_result = SIValue_ConvertToDouble(&result);
     char buffer[512];
     char *string_arg = NULL;
+    double numeric_arg;
 
     for(int i = 1; i < argc; i++) {
         if(SIValue_IsNull(argv[i])) return SI_NullVal();
 
         /* Perform numeric addition only if both result and current argument
          * are numeric. */
-        if(SI_TYPE(result) & SI_NUMERIC && SI_TYPE(argv[i]) & SI_NUMERIC) {
+        if(numeric_result && SIValue_ToDouble(&argv[i], &numeric_arg)) {
             /* Numeric addition. */
-            result.doubleval += argv[i].doubleval;
+            result.doubleval += numeric_arg;
         } else {
             /* String concatenation.
              * Make sure result is a String. */
-            if(SI_TYPE(result) & SI_NUMERIC) {
+            if(numeric_result) {
                 /* Result is numeric, convert to string. */
                 SIValue_ToString(result, buffer, 512);
                 result = SI_DuplicateStringVal(buffer);

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -316,8 +316,10 @@ void AR_EXP_Free(AR_ExpNode *root) {
 
 SIValue AR_ADD(SIValue *argv, int argc) {
     SIValue result = argv[0];
-    /* If the result is numeric, ensure that it is represented as a double. */
-    bool numeric_result = SIValue_ConvertToDouble(&result);
+    if(SI_TYPE(result) & SI_NUMERIC) {
+        /* If the result is numeric, ensure that it is represented as a double. */
+        SIValue_ConvertToDouble(&result);
+    }
     char buffer[512];
     char *string_arg = NULL;
     double numeric_arg;
@@ -327,13 +329,14 @@ SIValue AR_ADD(SIValue *argv, int argc) {
 
         /* Perform numeric addition only if both result and current argument
          * are numeric. */
-        if(numeric_result && SIValue_ToDouble(&argv[i], &numeric_arg)) {
+        if(SI_TYPE(result) & SI_NUMERIC && SI_TYPE(argv[i]) & SI_NUMERIC) {
+            SIValue_ToDouble(&argv[i], &numeric_arg);
             /* Numeric addition. */
             result.doubleval += numeric_arg;
         } else {
             /* String concatenation.
              * Make sure result is a String. */
-            if(numeric_result) {
+            if(SI_TYPE(result) & SI_NUMERIC) {
                 /* Result is numeric, convert to string. */
                 SIValue_ToString(result, buffer, 512);
                 result = SI_DuplicateStringVal(buffer);

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -61,11 +61,7 @@ void _traverse(CondTraverse *op) {
     else GxB_MatrixTupleIter_reuse(op->iter, op->M);
 
     // Clear filter matrix.
-    for(int i = 0; i < op->recordsLen; i++) {
-        Node *n = Record_GetNode(op->records[i], op->srcNodeRecIdx);
-        NodeID srcId = ENTITY_GET_ID(n);
-        GxB_Matrix_Delete(op->F, srcId, i);
-    }
+    GrB_Matrix_clear(op->F);
 }
 
 // Determin the maximum number of records

--- a/src/value.c
+++ b/src/value.c
@@ -225,12 +225,12 @@ int SIValue_ToString(SIValue v, char *buf, size_t len) {
   return bytes_written;
 }
 
-int SIValue_ToDouble(SIValue *v, double *d) {
+int SIValue_ToDouble(const SIValue *v, double *d) {
   switch (v->type) {
   case T_DOUBLE:
     *d = v->doubleval;
     return 1;
-  case T_INT64: // do nothing!
+  case T_INT64:
     *d = (double)v->longval;
     return 1;
   case T_INT32:
@@ -250,6 +250,35 @@ int SIValue_ToDouble(SIValue *v, double *d) {
     // cannot convert!
     return 0;
   }
+}
+
+int SIValue_ConvertToDouble(SIValue *v) {
+  switch (v->type) {
+    case T_DOUBLE:
+      return 1;
+    case T_INT64:
+      v->doubleval = (double)v->longval;
+      break;
+    case T_INT32:
+      v->doubleval = (double)v->intval;
+      break;
+    case T_UINT:
+      v->doubleval = (double)v->uintval;
+      break;
+    case T_FLOAT:
+      v->doubleval = (double)v->floatval;
+      break;
+    case T_BOOL:
+      v->doubleval = (double)v->boolval;
+      break;
+
+    default:
+      // cannot convert!
+      return 0;
+  }
+
+  v->type = T_DOUBLE;
+  return 1;
 }
 
 SIValue SIValue_FromString(const char *s) {

--- a/src/value.h
+++ b/src/value.h
@@ -92,7 +92,11 @@ int SI_ParseValue(SIValue *v, char *str);
 
 int SIValue_ToString(SIValue v, char *buf, size_t len);
 
-int SIValue_ToDouble(SIValue *v, double *d);
+/* Try to read a value as a double. */
+int SIValue_ToDouble(const SIValue *v, double *d);
+
+/* Try to internally convert a value to a double. */
+int SIValue_ConvertToDouble(SIValue *v);
 
 /* Try to parse a value by string. */
 SIValue SIValue_FromString(const char *s);


### PR DESCRIPTION
2 minor changes I have meant to make in this PR.

The addition change feels a little nitpicky, but it does resolve a rather improbable bug:
```
$ redis-cli GRAPH.QUERY G "MATCH (a) RETURN ID(a), ID(a) + 1"
1) 1) 1) "ID(a)"
      2) "ID(a) + 1.000000"
   2) 1) "0"
      2) "4607182418800017408"
   3) 1) "1"
      2) "4607182418800017408"
   4) 1) "2"
      2) "4607182418800017408"
```