### PR TITLE
Disjoint types should pass inequality comparisons

### DIFF
--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -98,8 +98,12 @@ FT_FilterNode* BuildFiltersTree(const AST *ast, const AST_FilterNode *root) {
  * Compares given values, tests if values maintain desired relation (op) */
 int _applyFilter(SIValue* aVal, SIValue* bVal, int op) {
     int rel = SIValue_Compare(*aVal, *bVal);
-    /* Always return false if values are not of comparable types. */
-    if (rel == DISJOINT) return 0;
+    /* Values are of disjoint types */
+    if (rel == DISJOINT) {
+        /* The filter passes if we're testing for inequality, and fails otherwise.*/
+        if (op == NE) return 1;
+        return 0;
+    }
 
     switch(op) {
         case EQ:

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -100,9 +100,8 @@ int _applyFilter(SIValue* aVal, SIValue* bVal, int op) {
     int rel = SIValue_Compare(*aVal, *bVal);
     /* Values are of disjoint types */
     if (rel == DISJOINT) {
-        /* The filter passes if we're testing for inequality, and fails otherwise.*/
-        if (op == NE) return 1;
-        return 0;
+        /* The filter passes if we're testing for inequality, and fails otherwise. */
+        return (op == NE);
     }
 
     switch(op) {

--- a/tests/flow/test_value_comparisons.py
+++ b/tests/flow/test_value_comparisons.py
@@ -75,6 +75,23 @@ class ValueComparisonTest(FlowTestsBase):
         actual_result = redis_graph.query(query)
         assert(actual_result.result_set[1][0] == '10.5')
 
+    # Verify that disjoint types pass != filters
+    def test_disjoint_comparisons(self):
+        # Compare all node pairs under a Cartesian product
+        query = """MATCH (v:value), (w:value) WHERE ID(v) != ID(w) AND v.val = w.val RETURN v"""
+        actual_result = redis_graph.query(query)
+        # No nodes have the same property, so there should be 0 equal results
+        expected_result_count = 0
+        assert(len(actual_result.result_set[1:]) == expected_result_count)
+
+        query = """MATCH (v:value), (w:value) WHERE ID(v) != ID(w) AND v.val != w.val RETURN v"""
+        actual_result = redis_graph.query(query)
+        # Every comparison should produce an inequal result
+        node_count = len(redis_graph.nodes)
+        expected_result_count = node_count * (node_count - 1)
+        assert(len(actual_result.result_set[1:]) == expected_result_count)
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
This was a kind of silly oversight:
```
$ redis-cli GRAPH.QUERY social "MATCH (p) WHERE p.name != 5 RETURN p"
1) (empty list or set)
2) 1) "Query internal execution time: 0.549209 milliseconds"
```
Fixed now!