### PR TITLE
Libcypher parser validations

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -78,7 +78,8 @@ void _MGraph_Query(void *args) {
 
     /* New parser */
     const char *query = RedisModule_StringPtrLen(qctx->query, NULL);
-    printf("query: %s\n", query);
+    // Debug print
+    // printf("query: %s\n", query);
     cypher_parse_result_t *new_ast = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
 
     char *parse_error_reason = NULL;

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -76,5 +76,22 @@ class QueryValidationFlowTest(FlowTestsBase):
             # Expecting an error.
             pass
 
+    def test04_invalid_entity_references(self):
+        try:
+            query = """MATCH (a) RETURN e"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError:
+            # Expecting an error.
+            pass
+
+        try:
+            query = """MATCH (a) RETURN a ORDER BY e"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError:
+            # Expecting an error.
+            pass
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Validations updated to pass the test suite, adding support for:
- Multiple MATCH clauses
- Aliases set in RETURN clauses
- Blocking interdependent paths (a limitation for us currently, not a Cypher constraint)

One validation still must be written that we don't currently have a test for:
`MATCH (n {name: v}) RETURN n`
This would previously fail in the parser with:
`Syntax error at offset 27 near 'v'`
