### PR TITLE
RESP-formatted result sets

### DIFF
--- a/demo/imdb/imdb_queries.py
+++ b/demo/imdb/imdb_queries.py
@@ -56,17 +56,17 @@ actors_over_50_that_played_in_blockbusters_query = QueryInfo(
              RETURN *""",
     description='Which actors who are over 50 played in blockbuster movies?',
     max_run_time_ms=4.0,
-    expected_result=[['Bill Irwin', '69.000000', 'Interstellar', '2014.000000', '961763.000000', '8.600000', 'Adventure'],
-                     ['Vincent Price', '108.000000', 'Vincent', '1982.000000', '18284.000000', '8.400000', 'Short'],
-                     ['Ellen Burstyn', '87.000000', 'Interstellar', '2014.000000', '961763.000000', '8.600000', 'Adventure'],
-                     ['Paul Reiser', '62.000000', 'Whiplash', '2014.000000', '420586.000000', '8.500000', 'Drama'],
-                     ['Francis X. McCarthy', '77.000000', 'Interstellar', '2014.000000', '961763.000000', '8.600000', 'Adventure'],
-                     ['John Lithgow', '74.000000', 'Interstellar', '2014.000000', '961763.000000', '8.600000', 'Adventure'],
-                     ['J.K. Simmons', '64.000000', 'Whiplash', '2014.000000', '420586.000000', '8.500000', 'Drama',],
-                     ['Chris Mulkey', '71.000000', 'Whiplash', '2014.000000', '420586.000000', '8.500000', 'Drama'],
-                     ['Rachael Harris', '51.000000', 'Lucifer', '2015.000000', '58703.000000', '8.300000', 'Crime'],
-                     ['Matthew McConaughey', '50.000000', 'Interstellar', '2014.000000', '961763.000000', '8.600000', 'Adventure'],
-                     ['D.B. Woodside', '50.000000', 'Lucifer', '2015.000000', '58703.000000', '8.300000', 'Crime']]
+    expected_result=[['Bill Irwin', '69', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
+                     ['Vincent Price', '108', 'Vincent', '1982', '18284', '8.4', 'Short'],
+                     ['Ellen Burstyn', '87', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
+                     ['Paul Reiser', '62', 'Whiplash', '2014', '420586', '8.5', 'Drama'],
+                     ['Francis X. McCarthy', '77', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
+                     ['John Lithgow', '74', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
+                     ['J.K. Simmons', '64', 'Whiplash', '2014', '420586', '8.5', 'Drama',],
+                     ['Chris Mulkey', '71', 'Whiplash', '2014', '420586', '8.5', 'Drama'],
+                     ['Rachael Harris', '51', 'Lucifer', '2015', '58703', '8.3', 'Crime'],
+                     ['Matthew McConaughey', '50', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
+                     ['D.B. Woodside', '50', 'Lucifer', '2015', '58703', '8.3', 'Crime']]
 
 )
 
@@ -79,21 +79,21 @@ actors_played_in_bad_drama_or_comedy_query = QueryInfo(
              ORDER BY m.rating""",
     description='Which actors played in bad drama or comedy?',
     max_run_time_ms=4,
-    expected_result=[['Rita Ora', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Dakota Johnson', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Marcia Gay Harden', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Jamie Dornan', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Eloise Mumford', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Max Martini', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Luke Grimes', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Jennifer Ehle', 'Fifty Shades of Grey', '2015.000000', '224710.000000', '4.100000', 'Drama'],
-                     ['Victor Rasuk', 'Fifty Shades of Grey', '2015.000000','224710.000000', '4.100000', 'Drama'],
-                     ['Nancy Lenehan', 'Sex Tape', '2014.000000', '86018.000000', '5.100000', 'Comedy'],
-                     ['Rob Lowe', 'Sex Tape', '2014.000000', '86018.000000', '5.100000', 'Comedy'],
-                     ['Cameron Diaz', 'Sex Tape', '2014.000000', '86018.000000', '5.100000', 'Comedy'],
-                     ['Rob Corddry', 'Sex Tape', '2014.000000', '86018.000000', '5.100000', 'Comedy'],
-                     ['Jason Segel', 'Sex Tape', '2014.000000', '86018.000000', '5.100000', 'Comedy'],
-                     ['Ellie Kemper', 'Sex Tape', '2014.000000', '86018.000000', '5.100000', 'Comedy']]
+    expected_result=[['Rita Ora', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Dakota Johnson', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Marcia Gay Harden', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Jamie Dornan', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Eloise Mumford', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Max Martini', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Luke Grimes', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Jennifer Ehle', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
+                     ['Victor Rasuk', 'Fifty Shades of Grey', '2015','224710', '4.1', 'Drama'],
+                     ['Nancy Lenehan', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
+                     ['Rob Lowe', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
+                     ['Cameron Diaz', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
+                     ['Rob Corddry', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
+                     ['Jason Segel', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
+                     ['Ellie Kemper', 'Sex Tape', '2014', '86018', '5.1', 'Comedy']]
 )
 
 
@@ -103,8 +103,8 @@ young_actors_played_with_cameron_diaz_query = QueryInfo(
              RETURN a, m.title""",
     description='Which young actors played along side Cameron Diaz?',
     max_run_time_ms=5,
-    expected_result=[['Nicolette Pierini', '16.000000', 'Annie'],
-                     ['Kate Upton', '27.000000', 'The Other Woman']]
+    expected_result=[['Nicolette Pierini', '16', 'Annie'],
+                     ['Kate Upton', '27', 'The Other Woman']]
 )
 
 
@@ -114,13 +114,13 @@ actors_played_with_cameron_diaz_and_younger_than_her_query = QueryInfo(
              RETURN a, m.title order by a.name""",
     description='Which actors played along side Cameron Diaz and are younger then her?',
     max_run_time_ms=7,
-    expected_result=[['Jason Segel', '39.000000', 'Sex Tape'],
-                     ['Ellie Kemper', '39.000000', 'Sex Tape'],
-                     ['Nicolette Pierini', '16.000000', 'Annie'],
-                     ['Rose Byrne', '40.000000', 'Annie'],
-                     ['Kate Upton', '27.000000', 'The Other Woman'],
-                     ['Nicki Minaj', '37.000000', 'The Other Woman'],
-                     ['Taylor Kinney', '38.000000', 'The Other Woman']]
+    expected_result=[['Jason Segel', '39', 'Sex Tape'],
+                     ['Ellie Kemper', '39', 'Sex Tape'],
+                     ['Nicolette Pierini', '16', 'Annie'],
+                     ['Rose Byrne', '40', 'Annie'],
+                     ['Kate Upton', '27', 'The Other Woman'],
+                     ['Nicki Minaj', '37', 'The Other Woman'],
+                     ['Taylor Kinney', '38', 'The Other Woman']]
 )
 
 
@@ -129,7 +129,7 @@ sum_and_average_age_of_straight_outta_compton_cast_query = QueryInfo(
              RETURN m.title, SUM(a.age), AVG(a.age)""",
     description='What is the sum and average age of the Straight Outta Compton cast?',
     max_run_time_ms=4,
-    expected_result=[['Straight Outta Compton', '131.000000', '32.750000']]
+    expected_result=[['Straight Outta Compton', '131', '32.75']]
 )
 
 
@@ -138,7 +138,7 @@ how_many_movies_cameron_diaz_played_query = QueryInfo(
              RETURN Cameron.name, COUNT(m.title)""",
     description='In how many movies did Cameron Diaz played?',
     max_run_time_ms=1.2,
-    expected_result=[['Cameron Diaz', '3.000000']]
+    expected_result=[['Cameron Diaz', '3']]
 )
 
 
@@ -149,16 +149,16 @@ find_ten_oldest_actors_query = QueryInfo(
              LIMIT 10""",
     description='10 Oldest actors?',
     max_run_time_ms=4.5,
-    expected_result=[['Vincent Price', '108.000000'],
-                     ['George Kennedy', '94.000000'],
-                     ['Cloris Leachman', '93.000000'],
-                     ['John Cullum', '89.000000'],
-                     ['Lois Smith', '89.000000'],
-                     ['Robert Duvall', '88.000000'],
-                     ['Olympia Dukakis', '88.000000'],
-                     ['Ellen Burstyn', '87.000000'],
-                     ['Michael Caine', '86.000000'],
-                     ['Judi Dench', '85.000000']]
+    expected_result=[['Vincent Price', '108'],
+                     ['George Kennedy', '94'],
+                     ['Cloris Leachman', '93'],
+                     ['John Cullum', '89'],
+                     ['Lois Smith', '89'],
+                     ['Robert Duvall', '88'],
+                     ['Olympia Dukakis', '88'],
+                     ['Ellen Burstyn', '87'],
+                     ['Michael Caine', '86'],
+                     ['Judi Dench', '85']]
 )
 
 actors_over_85_index_scan = QueryInfo(
@@ -168,15 +168,15 @@ actors_over_85_index_scan = QueryInfo(
              ORDER BY a.age, a.name""",
     description='Actors over 85 on indexed property?',
     max_run_time_ms=1.5,
-    expected_result=[['Michael Caine', '86.000000'],
-                     ['Ellen Burstyn', '87.000000'],
-                     ['Robert Duvall', '88.000000'],
-                     ['Olympia Dukakis', '88.000000'],
-                     ['Lois Smith', '89.000000'],
-                     ['John Cullum', '89.000000'],
-                     ['Cloris Leachman', '93.000000'],
-                     ['George Kennedy', '94.000000'],
-                     ['Vincent Price', '108.000000']]
+    expected_result=[['Michael Caine', '86'],
+                     ['Ellen Burstyn', '87'],
+                     ['Robert Duvall', '88'],
+                     ['Olympia Dukakis', '88'],
+                     ['Lois Smith', '89'],
+                     ['John Cullum', '89'],
+                     ['Cloris Leachman', '93'],
+                     ['George Kennedy', '94'],
+                     ['Vincent Price', '108']]
 )
 
 eighties_movies_index_scan = QueryInfo(
@@ -187,8 +187,8 @@ eighties_movies_index_scan = QueryInfo(
              ORDER BY m.year""",
     description='Multiple filters on indexed property?',
     max_run_time_ms=1.5,
-    expected_result=[['The Evil Dead', '1981.000000'],
-                     ['Vincent', '1982.000000']]
+    expected_result=[['The Evil Dead', '1981'],
+                     ['Vincent', '1982']]
 )
 
 find_titles_starting_with_american_query = QueryInfo(

--- a/demo/social/social_queries.py
+++ b/demo/social/social_queries.py
@@ -41,8 +41,8 @@ relation_type_counts = QueryInfo(
     query="""MATCH ()-[e]->() RETURN TYPE(e) as relation_type, COUNT(e) as num_relations ORDER BY relation_type, num_relations""",
     description='Returns each relation type in the graph and its count.',
     max_run_time_ms=0.4,
-    expected_result=[['friend', '13.000000'],
-                     ['visited', '35.000000']]
+    expected_result=[['friend', '13'],
+                     ['visited', '35']]
 )
 
 subset_of_people = QueryInfo(
@@ -89,7 +89,7 @@ friends_of_friends_single_and_over_30_query = QueryInfo(
              RETURN fof""",
     description='Friends of friends who are single and over 30?',
     max_run_time_ms=0.25,
-    expected_result=[['Noam Nativ', '34.000000', 'male', 'single']]
+    expected_result=[['Noam Nativ', '34', 'male', 'single']]
 )
 
 friends_of_friends_visited_amsterdam_and_single_query = QueryInfo(
@@ -123,7 +123,7 @@ friends_older_than_me_query = QueryInfo(
              RETURN f.name, f.age""",
     description='Friends who are older than me?',
     max_run_time_ms=0.25,
-    expected_result=[['Omri Traub', '33.000000']]
+    expected_result=[['Omri Traub', '33']]
 )
 
 friends_age_difference_query = QueryInfo(
@@ -132,12 +132,12 @@ friends_age_difference_query = QueryInfo(
              ORDER BY age_diff desc""",
     description='Age difference between me and each of my friends.',
     max_run_time_ms=0.35,
-    expected_result=[['Boaz Arad', '1.000000'],
-                     ['Omri Traub', '1.000000'],
-                     ['Ailon Velger', '0.000000'],
-                     ['Tal Doron', '0.000000'],
-                     ['Ori Laslo', '0.000000'],
-                     ['Alon Fital', '0.000000']]
+    expected_result=[['Boaz Arad', '1'],
+                     ['Omri Traub', '1'],
+                     ['Ailon Velger', '0'],
+                     ['Tal Doron', '0'],
+                     ['Ori Laslo', '0'],
+                     ['Alon Fital', '0']]
 )
 
 how_many_countries_each_friend_visited_query = QueryInfo(
@@ -147,11 +147,11 @@ how_many_countries_each_friend_visited_query = QueryInfo(
              LIMIT 10""",
     description='Count for each friend how many countires he or she been to?',
     max_run_time_ms=0.3,
-    expected_result=[['Alon Fital', '3.000000'],
-                     ['Omri Traub', '3.000000'],
-                     ['Tal Doron', '3.000000'],
-                     ['Ori Laslo', '3.000000'],
-                     ['Boaz Arad', '2.000000']]
+    expected_result=[['Alon Fital', '3'],
+                     ['Omri Traub', '3'],
+                     ['Tal Doron', '3'],
+                     ['Ori Laslo', '3'],
+                     ['Boaz Arad', '2']]
 )
 
 happy_birthday_query = QueryInfo(
@@ -167,7 +167,7 @@ friends_age_statistics_query = QueryInfo(
              RETURN ME.name, count(f.name), sum(f.age), avg(f.age), min(f.age), max(f.age)""",
     description='Friends age statistics.',
     max_run_time_ms=0.2,
-    expected_result=[['Roi Lipman', '6.000000', '198.000000', '33.000000', '32.000000', '34.000000']]
+    expected_result=[['Roi Lipman', '6', '198', '33', '32', '34']]
 )
 
 visit_purpose_of_each_country_i_visited_query = QueryInfo(
@@ -200,13 +200,13 @@ number_of_vacations_per_person_query = QueryInfo(
              LIMIT 6""",
     description='Count number of vacations per person?',
     max_run_time_ms=0.5,
-    expected_result=[['Noam Nativ', '3.000000'],
-                     ['Shelly Laslo Rooz', '3.000000'],
-                     ['Omri Traub', '3.000000'],
-                     ['Lucy Yanfital', '2.000000'],
-                     ['Jane Chernomorin', '2.000000'],
-                     ['Mor Yesharim', '2.000000'],
-                     ['Valerie Abigail Arad', '2.000000']]
+    expected_result=[['Noam Nativ', '3'],
+                     ['Shelly Laslo Rooz', '3'],
+                     ['Omri Traub', '3'],
+                     ['Lucy Yanfital', '2'],
+                     ['Jane Chernomorin', '2'],
+                     ['Mor Yesharim', '2'],
+                     ['Valerie Abigail Arad', '2']]
 )
 
 all_reachable_friends_query = QueryInfo(
@@ -236,19 +236,19 @@ all_reachable_countries_query = QueryInfo(
              ORDER BY NumPathsToCountry DESC""",
     description='Find all reachable countries',
     max_run_time_ms=0.6,
-    expected_result=[['USA', '9.000000'],
-                     ['Amsterdam', '5.000000'],
-                     ['Greece', '4.000000'],
-                     ['Prague', '3.000000'],
-                     ['Germany', '2.000000'],
-                     ['Andora', '2.000000'],
-                     ['Japan', '2.000000'],
-                     ['Canada', '2.000000'],
-                     ['China', '2.000000'],
-                     ['Kazakhstan', '1.000000'],
-                     ['Thailand', '1.000000'],
-                     ['Italy', '1.000000'],
-                     ['Russia', '1.000000']]
+    expected_result=[['USA', '9'],
+                     ['Amsterdam', '5'],
+                     ['Greece', '4'],
+                     ['Prague', '3'],
+                     ['Germany', '2'],
+                     ['Andora', '2'],
+                     ['Japan', '2'],
+                     ['Canada', '2'],
+                     ['China', '2'],
+                     ['Kazakhstan', '1'],
+                     ['Thailand', '1'],
+                     ['Italy', '1'],
+                     ['Russia', '1']]
 )
 
 reachable_countries_or_people_query = QueryInfo(
@@ -274,32 +274,32 @@ all_reachable_countries_or_people_query = QueryInfo(
              ORDER BY NumPathsToEntity DESC""",
     description='Every reachable person or country from source node',
     max_run_time_ms=0.4,
-    expected_result=[['USA', '9.000000'],
-                     ['Amsterdam', '5.000000'],
-                     ['Greece', '4.000000'],
-                     ['Prague', '3.000000'],
-                     ['Germany', '2.000000'],
-                     ['Japan', '2.000000'],
-                     ['Andora', '2.000000'],
-                     ['Canada', '2.000000'],
-                     ['China', '2.000000'],
-                     ['Ailon Velger', '1.000000'],
-                     ['Alon Fital', '1.000000'],
-                     ['Gal Derriere', '1.000000'],
-                     ['Jane Chernomorin', '1.000000'],
-                     ['Omri Traub', '1.000000'],
-                     ['Boaz Arad', '1.000000'],
-                     ['Noam Nativ', '1.000000'],
-                     ['Shelly Laslo Rooz', '1.000000'],
-                     ['Russia', '1.000000'],
-                     ['Valerie Abigail Arad', '1.000000'],
-                     ['Mor Yesharim', '1.000000'],
-                     ['Italy', '1.000000'],
-                     ['Tal Doron', '1.000000'],
-                     ['Thailand', '1.000000'],
-                     ['Kazakhstan', '1.000000'],
-                     ['Lucy Yanfital', '1.000000'],
-                     ['Ori Laslo', '1.000000']]
+    expected_result=[['USA', '9'],
+                     ['Amsterdam', '5'],
+                     ['Greece', '4'],
+                     ['Prague', '3'],
+                     ['Germany', '2'],
+                     ['Japan', '2'],
+                     ['Andora', '2'],
+                     ['Canada', '2'],
+                     ['China', '2'],
+                     ['Ailon Velger', '1'],
+                     ['Alon Fital', '1'],
+                     ['Gal Derriere', '1'],
+                     ['Jane Chernomorin', '1'],
+                     ['Omri Traub', '1'],
+                     ['Boaz Arad', '1'],
+                     ['Noam Nativ', '1'],
+                     ['Shelly Laslo Rooz', '1'],
+                     ['Russia', '1'],
+                     ['Valerie Abigail Arad', '1'],
+                     ['Mor Yesharim', '1'],
+                     ['Italy', '1'],
+                     ['Tal Doron', '1'],
+                     ['Thailand', '1'],
+                     ['Kazakhstan', '1'],
+                     ['Lucy Yanfital', '1'],
+                     ['Ori Laslo', '1']]
 )
 
 all_reachable_entities_query = QueryInfo(
@@ -308,32 +308,32 @@ all_reachable_entities_query = QueryInfo(
              ORDER BY NumPathsToEntity DESC""",
     description='Find all reachable entities',
     max_run_time_ms=0.4,
-    expected_result=[['USA', '9.000000'],
-                     ['Amsterdam', '5.000000'],
-                     ['Greece', '4.000000'],
-                     ['Prague', '3.000000'],
-                     ['Germany', '2.000000'],
-                     ['Japan', '2.000000'],
-                     ['Andora', '2.000000'],
-                     ['Canada', '2.000000'],
-                     ['China', '2.000000'],
-                     ['Ailon Velger', '1.000000'],
-                     ['Alon Fital', '1.000000'],
-                     ['Gal Derriere', '1.000000'],
-                     ['Jane Chernomorin', '1.000000'],
-                     ['Omri Traub', '1.000000'],
-                     ['Boaz Arad', '1.000000'],
-                     ['Noam Nativ', '1.000000'],
-                     ['Shelly Laslo Rooz', '1.000000'],
-                     ['Russia', '1.000000'],
-                     ['Valerie Abigail Arad', '1.000000'],
-                     ['Mor Yesharim', '1.000000'],
-                     ['Italy', '1.000000'],
-                     ['Tal Doron', '1.000000'],
-                     ['Thailand', '1.000000'],
-                     ['Kazakhstan', '1.000000'],
-                     ['Lucy Yanfital', '1.000000'],
-                     ['Ori Laslo', '1.000000']]
+    expected_result=[['USA', '9'],
+                     ['Amsterdam', '5'],
+                     ['Greece', '4'],
+                     ['Prague', '3'],
+                     ['Germany', '2'],
+                     ['Japan', '2'],
+                     ['Andora', '2'],
+                     ['Canada', '2'],
+                     ['China', '2'],
+                     ['Ailon Velger', '1'],
+                     ['Alon Fital', '1'],
+                     ['Gal Derriere', '1'],
+                     ['Jane Chernomorin', '1'],
+                     ['Omri Traub', '1'],
+                     ['Boaz Arad', '1'],
+                     ['Noam Nativ', '1'],
+                     ['Shelly Laslo Rooz', '1'],
+                     ['Russia', '1'],
+                     ['Valerie Abigail Arad', '1'],
+                     ['Mor Yesharim', '1'],
+                     ['Italy', '1'],
+                     ['Tal Doron', '1'],
+                     ['Thailand', '1'],
+                     ['Kazakhstan', '1'],
+                     ['Lucy Yanfital', '1'],
+                     ['Ori Laslo', '1']]
 )
 
 delete_friendships_query = QueryInfo(

--- a/src/arithmetic/aggregate.c
+++ b/src/arithmetic/aggregate.c
@@ -25,9 +25,6 @@ AggCtx *Agg_NewCtx(void *fctx) {
 }
 
 void AggCtx_Free(AggCtx *ctx) {
-  if (ctx->err) {
-    free(ctx->err);
-  }
   free(ctx->fctx);
   SIValue_Free(&ctx->result);
   free(ctx);

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -302,12 +302,14 @@ void AR_EXP_ToString(const AR_ExpNode *root, char **str) {
 }
 
 void AR_EXP_Free(AR_ExpNode *root) {
-    // TODO: I believe we don't handle freeing aggregated functions correctly
     if(root->type == AR_EXP_OP) {
         for(int child_idx = 0; child_idx < root->op.child_count; child_idx++) {
             AR_EXP_Free(root->op.children[child_idx]);
         }
         free(root->op.children);
+        if (root->op.type == AR_OP_AGGREGATE) {
+            AggCtx_Free(root->op.agg_func);
+        }
     } else {
         if (root->operand.type == AR_EXP_CONSTANT) {
             SIValue_Free(&root->operand.constant);

--- a/src/execution_plan/ops/op_aggregate.c
+++ b/src/execution_plan/ops/op_aggregate.c
@@ -21,7 +21,7 @@ static void _build_expressions(Aggregate *op) {
     uint expCount = array_len(return_node->returnElements);
     
     op->none_aggregated_expressions = array_new(AR_ExpNode*, 1);
-    op->expression_classification = rm_malloc(sizeof(int) * expCount);
+    op->expression_classification = rm_malloc(sizeof(uint8_t) * expCount);
 
     // Compose RETURN clause expressions.
     for(uint i = 0; i < expCount; i++) {
@@ -33,6 +33,7 @@ static void _build_expressions(Aggregate *op) {
             op->none_aggregated_expressions = array_append(op->none_aggregated_expressions, exp);
         } else {
             op->expression_classification[i] = 1;
+            AR_EXP_Free(exp);
         }
     }
 
@@ -68,9 +69,9 @@ static Group* _CreateGroup(Aggregate *op, Record r) {
     AR_ExpNode **agg_exps = _build_aggregated_expressions(op);
 
     /* Clone group keys. */
-    size_t key_count = array_len(op->none_aggregated_expressions);
+    uint32_t key_count = array_len(op->none_aggregated_expressions);
     SIValue *group_keys = rm_malloc(sizeof(SIValue) * key_count);
-    for(int i = 0; i < key_count; i++) group_keys[i] = op->group_keys[i];
+    for(uint32_t i = 0; i < key_count; i++) group_keys[i] = op->group_keys[i];
 
     // There's no need to keep a reference to record
     // if we're not performing aggregations.

--- a/src/execution_plan/ops/op_aggregate.h
+++ b/src/execution_plan/ops/op_aggregate.h
@@ -25,7 +25,7 @@
     ResultSet *resultset;
     AR_ExpNode **none_aggregated_expressions;   /* Array of arithmetic expression. */
     AR_ExpNode **order_expressions;             /* Array of arithmetic expression. */
-    int *expression_classification;             /* 1 if RETURN_CLAUSE[i] is aggregated, 0 otherwise.  */
+    uint8_t *expression_classification;         /* 1 if RETURN_CLAUSE[i] is aggregated, 0 otherwise.  */
     SIValue *group_keys;                        /* Array of values composing an aggregated group. */
     TrieMap *groups;
     CacheGroupIterator *groupIter;

--- a/src/grouping/group.c
+++ b/src/grouping/group.c
@@ -26,7 +26,12 @@ Group* NewGroup(int key_count, SIValue* keys, AR_ExpNode** funcs, Record r) {
 void FreeGroup(Group* g) {
     if(g == NULL) return;
     if(g->r) Record_Free(g->r);
-    if(g->key_count) rm_free(g->keys);
+    if(g->keys) {
+        for (int i = 0; i < g->key_count; i ++) {
+            SIValue_Free(&g->keys[i]);
+        }
+        rm_free(g->keys);
+    }
     if(g->aggregationFunctions) {
         for(uint32_t i = 0; i < array_len(g->aggregationFunctions); i++) {
             AR_ExpNode *exp = g->aggregationFunctions[i];

--- a/src/grouping/group_cache.c
+++ b/src/grouping/group_cache.c
@@ -29,8 +29,7 @@ void FreeGroupCache(CacheGroup *groups) {
 
 // Returns an iterator to scan entire group cache
 CacheGroupIterator* CacheGroupIter(CacheGroup *groups) {
-    char *prefix = "";
-	return TrieMap_Iterate(groups, prefix, strlen(prefix));
+    return TrieMap_Iterate(groups, "", 0);
 }
 
 // Advance iterator and returns key & value in current position.

--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -64,38 +64,38 @@ class GraphBulkInsertFlowTest(FlowTestsBase):
         query_result = redis_graph.query('MATCH (p:Person) RETURN p, ID(p) ORDER BY p.name')
         # Verify that the Person label exists, has the correct attributes, and is properly populated
         expected_result = [['p.name', 'p.age', 'p.gender', 'p.status', 'ID(p)'],
-                           ['Ailon Velger', '32.000000', 'male', 'married', '2'],
-                           ['Alon Fital', '32.000000', 'male', 'married', '1'],
-                           ['Boaz Arad', '31.000000', 'male', 'married', '4'],
-                           ['Gal Derriere', '26.000000', 'male', 'single', '11'],
-                           ['Jane Chernomorin', '31.000000', 'female', 'married', '8'],
-                           ['Lucy Yanfital', '30.000000', 'female', 'married', '7'],
-                           ['Mor Yesharim', '31.000000', 'female', 'married', '12'],
-                           ['Noam Nativ', '34.000000', 'male', 'single', '13'],
-                           ['Omri Traub', '33.000000', 'male', 'single', '5'],
-                           ['Ori Laslo', '32.000000', 'male', 'married', '3'],
-                           ['Roi Lipman', '32.000000', 'male', 'married', '0'],
-                           ['Shelly Laslo Rooz', '31.000000', 'female', 'married', '9'],
-                           ['Tal Doron', '32.000000', 'male', 'single', '6'],
-                           ['Valerie Abigail Arad', '31.000000', 'female', 'married', '10']]
+                           ['Ailon Velger', '32', 'male', 'married', 2],
+                           ['Alon Fital', '32', 'male', 'married', 1],
+                           ['Boaz Arad', '31', 'male', 'married', 4],
+                           ['Gal Derriere', '26', 'male', 'single', 11],
+                           ['Jane Chernomorin', '31', 'female', 'married', 8],
+                           ['Lucy Yanfital', '30', 'female', 'married', 7],
+                           ['Mor Yesharim', '31', 'female', 'married', 12],
+                           ['Noam Nativ', '34', 'male', 'single', 13],
+                           ['Omri Traub', '33', 'male', 'single', 5],
+                           ['Ori Laslo', '32', 'male', 'married', 3],
+                           ['Roi Lipman', '32', 'male', 'married', 0],
+                           ['Shelly Laslo Rooz', '31', 'female', 'married', 9],
+                           ['Tal Doron', '32', 'male', 'single', 6],
+                           ['Valerie Abigail Arad', '31', 'female', 'married', 10]]
         assert query_result.result_set == expected_result
 
         # Verify that the Country label exists, has the correct attributes, and is properly populated
         query_result = redis_graph.query('MATCH (c:Country) RETURN c, ID(c) ORDER BY c.name')
         expected_result = [['c.name', 'ID(c)'],
-                           ['Amsterdam', '20'],
-                           ['Andora', '21'],
-                           ['Canada', '18'],
-                           ['China', '19'],
-                           ['Germany', '24'],
-                           ['Greece', '17'],
-                           ['Italy', '25'],
-                           ['Japan', '16'],
-                           ['Kazakhstan', '22'],
-                           ['Prague', '15'],
-                           ['Russia', '23'],
-                           ['Thailand', '26'],
-                           ['USA', '14']]
+                           ['Amsterdam', 20],
+                           ['Andora', 21],
+                           ['Canada', 18],
+                           ['China', 19],
+                           ['Germany', 24],
+                           ['Greece', 17],
+                           ['Italy', 25],
+                           ['Japan', 16],
+                           ['Kazakhstan', 22],
+                           ['Prague', 15],
+                           ['Russia', 23],
+                           ['Thailand', 26],
+                           ['USA', 14]]
         assert query_result.result_set == expected_result
 
     # Validate that the expected relations and properties have been constructed
@@ -348,9 +348,9 @@ class GraphBulkInsertFlowTest(FlowTestsBase):
         graph = Graph(graphname, redis_con)
         query_result = graph.query('MATCH (a)-[e]->() RETURN a, e ORDER BY a.numeric, e.prop')
         expected_result = [['a.numeric', 'a.mixed', 'a.bool', 'e.prop'],
-                           ['0.000000', 'NULL', 'true', 'true'],
-                           ['5.000000', 'notnull', 'false', '3.500000'],
-                           ['7.000000', 'NULL', 'false', 'NULL']]
+                           ['0', None, 'true', 'true'],
+                           ['5', 'notnull', 'false', '3.5'],
+                           ['7', None, 'false', None]]
 
         # The graph should have the correct types for all properties
         assert query_result.result_set == expected_result

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -118,7 +118,7 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (charlie { name: 'Charlie Sheen' }) RETURN charlie"""
         actual_result = redis_graph.query(query)
         expected_result = [['charlie.age', 'charlie.name', 'charlie.lastname'],
-                           ['11.000000', 'Charlie Sheen', 'Sheen']]
+                           ['11', 'Charlie Sheen', 'Sheen']]
         assert(actual_result.result_set == expected_result)
 
     # Update new entity
@@ -134,7 +134,7 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (tamara:ACTOR { name: 'Tamara Tunie' }) RETURN tamara"""
         actual_result = redis_graph.query(query)
         expected_result = [['tamara.name', 'tamara.age'],
-                           ['Tamara Tunie', '59.000000']]
+                           ['Tamara Tunie', '59']]
         assert(actual_result.result_set == expected_result)
 
     # Create a single edge and additional two nodes.
@@ -160,7 +160,7 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (franklin:ACTOR { name: 'Franklin Cover' })-[r:ACTED_IN {rate:5.9, date:1998}]->(almostHeroes:MOVIE) RETURN franklin.name, franklin.age, r.rate, r.date"""
         actual_result = redis_graph.query(query)
         expected_result = [['franklin.name', 'franklin.age', 'r.rate', 'r.date'],
-                           ['Franklin Cover', 'NULL', '5.900000', '1998.000000']]
+                           ['Franklin Cover', None, '5.9', '1998']]
         assert(actual_result.result_set == expected_result)
     
 
@@ -182,10 +182,10 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (p:person) RETURN p"""
         actual_result = redis_graph.query(query)
         expected_result = [['p.age', 'p.newprop'],
-                           ['31.000000', '100.000000'],
-                           ['31.000000', '100.000000'],
-                           ['31.000000', '100.000000'],
-                           ['31.000000', '100.000000']]
+                           ['31', '100'],
+                           ['31', '100'],
+                           ['31', '100'],
+                           ['31', '100']]
         assert(actual_result.result_set == expected_result)
 
     # Update multiple nodes

--- a/tests/flow/test_multi_exec.py
+++ b/tests/flow/test_multi_exec.py
@@ -80,7 +80,7 @@ class MultiExecFlowTest(FlowTestsBase):
         # [
         #   [
         #       ['al.name', 'count(b)'],
-        #       ['Al', '2.000000']
+        #       ['Al', '2']
         #   ],
         #       ['Query internal execution time: 0.143000 milliseconds']
         # ]

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -177,7 +177,7 @@ class GraphPersistency(FlowTestsBase):
         # Note that the order of results is not guaranteed (currently managed by the Schema),
         # so this may need to be updated in the future.
         expected_result = [['p.boolval', 'p.nullval', 'p.numval', 'p.strval'],
-                           ['true', 'NULL', '5.500000', 'str']]
+                           ['true', None, '5.5', 'str']]
         assert(actual_result.result_set == expected_result)
 
     # Verify that the database can be reloaded correctly after creating multiple
@@ -201,7 +201,7 @@ class GraphPersistency(FlowTestsBase):
         read_query = """MATCH (a)-[e]->(b) RETURN e, a, b"""
         actual_result = graph.query(read_query)
         expected_result = [['e.val', 'a.name', 'b.name'],
-                           ['1.000000', 'src', 'dest']]
+                           ['1', 'src', 'dest']]
         assert(actual_result.result_set == expected_result)
 
         # Overwrite the existing edge
@@ -212,7 +212,7 @@ class GraphPersistency(FlowTestsBase):
         actual_result = graph.query(read_query)
         # TODO This is the expected current behavior, subject to later change.
         expected_result = [['e.val', 'a.name', 'b.name'],
-                           ['2.000000', 'src', 'dest']]
+                           ['2', 'src', 'dest']]
         assert(actual_result.result_set == expected_result)
 
         # Save RDB & Load from RDB

--- a/tests/flow/test_value_comparisons.py
+++ b/tests/flow/test_value_comparisons.py
@@ -53,9 +53,9 @@ class ValueComparisonTest(FlowTestsBase):
                     ['str2'],
                     ['false'],
                     ['true'],
-                    ['5.000000'],
-                    ['10.500000'],
-                    ['NULL']]
+                    ['5'],
+                    ['10.5'],
+                    [None]]
         assert(actual_result.result_set[1:] == expected)
 
         # Expect the results to appear in reverse when using descending order
@@ -73,7 +73,7 @@ class ValueComparisonTest(FlowTestsBase):
     def test_mixed_type_max(self):
         query = """MATCH (v:value) RETURN MAX(v.val)"""
         actual_result = redis_graph.query(query)
-        assert(actual_result.result_set[1][0] == '10.500000')
+        assert(actual_result.result_set[1][0] == '10.5')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a quality-of-life PR for outputting better-sanitized result sets with Redis's RESP protocol.
Example:
`redis-cli GRAPH.QUERY G "CREATE (:a {strval: 'string_prop', doubleval: 7.3, nullval: NULL})"`
Before:
```
redis-cli GRAPH.QUERY G "MATCH (a) RETURN a, ID(a)"
1) 1) 1) "a.nullval"
      2) "a.doubleval"
      3) "a.strval"
      4) "ID(a)"
   2) 1) "NULL"
      2) "7.300000"
      3) "string_prop"
      4) "0"
```
After:
```
redis-cli GRAPH.QUERY G "MATCH (a) RETURN a, ID(a)"
1) 1) 1) "a.nullval"
      2) "a.doubleval"
      3) "a.strval"
      4) "ID(a)"
   2) 1) (nil)
      2) "7.3"
      3) "string_prop"
      4) (integer) 0
```
`(nil)` and `(integer)` are redis-cli builtins. Clients will use their native representations, such as NULL being `None` for `redis-py`.

This should help ameliorate the issues described in #354.