### PR TITLE
Support 8-byte integers as a user type

### DIFF
--- a/demo/imdb/imdb_queries.py
+++ b/demo/imdb/imdb_queries.py
@@ -56,17 +56,17 @@ actors_over_50_that_played_in_blockbusters_query = QueryInfo(
              RETURN *""",
     description='Which actors who are over 50 played in blockbuster movies?',
     max_run_time_ms=4.0,
-    expected_result=[['Bill Irwin', '69', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
-                     ['Vincent Price', '108', 'Vincent', '1982', '18284', '8.4', 'Short'],
-                     ['Ellen Burstyn', '87', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
-                     ['Paul Reiser', '62', 'Whiplash', '2014', '420586', '8.5', 'Drama'],
-                     ['Francis X. McCarthy', '77', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
-                     ['John Lithgow', '74', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
-                     ['J.K. Simmons', '64', 'Whiplash', '2014', '420586', '8.5', 'Drama',],
-                     ['Chris Mulkey', '71', 'Whiplash', '2014', '420586', '8.5', 'Drama'],
-                     ['Rachael Harris', '51', 'Lucifer', '2015', '58703', '8.3', 'Crime'],
-                     ['Matthew McConaughey', '50', 'Interstellar', '2014', '961763', '8.6', 'Adventure'],
-                     ['D.B. Woodside', '50', 'Lucifer', '2015', '58703', '8.3', 'Crime']]
+    expected_result=[['Bill Irwin', 69, 'Interstellar', 2014, 961763, '8.6', 'Adventure'],
+                     ['Vincent Price', 108, 'Vincent', 1982, 18284, '8.4', 'Short'],
+                     ['Ellen Burstyn', 87, 'Interstellar', 2014, 961763, '8.6', 'Adventure'],
+                     ['Paul Reiser', 62, 'Whiplash', 2014, 420586, '8.5', 'Drama'],
+                     ['Francis X. McCarthy', 77, 'Interstellar', 2014, 961763, '8.6', 'Adventure'],
+                     ['John Lithgow', 74, 'Interstellar', 2014, 961763, '8.6', 'Adventure'],
+                     ['J.K. Simmons', 64, 'Whiplash', 2014, 420586, '8.5', 'Drama',],
+                     ['Chris Mulkey', 71, 'Whiplash', 2014, 420586, '8.5', 'Drama'],
+                     ['Rachael Harris', 51, 'Lucifer', 2015, 58703, '8.3', 'Crime'],
+                     ['Matthew McConaughey', 50, 'Interstellar', 2014, 961763, '8.6', 'Adventure'],
+                     ['D.B. Woodside', 50, 'Lucifer', 2015, 58703, '8.3', 'Crime']]
 
 )
 
@@ -79,21 +79,21 @@ actors_played_in_bad_drama_or_comedy_query = QueryInfo(
              ORDER BY m.rating""",
     description='Which actors played in bad drama or comedy?',
     max_run_time_ms=4,
-    expected_result=[['Rita Ora', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Dakota Johnson', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Marcia Gay Harden', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Jamie Dornan', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Eloise Mumford', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Max Martini', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Luke Grimes', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Jennifer Ehle', 'Fifty Shades of Grey', '2015', '224710', '4.1', 'Drama'],
-                     ['Victor Rasuk', 'Fifty Shades of Grey', '2015','224710', '4.1', 'Drama'],
-                     ['Nancy Lenehan', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
-                     ['Rob Lowe', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
-                     ['Cameron Diaz', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
-                     ['Rob Corddry', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
-                     ['Jason Segel', 'Sex Tape', '2014', '86018', '5.1', 'Comedy'],
-                     ['Ellie Kemper', 'Sex Tape', '2014', '86018', '5.1', 'Comedy']]
+    expected_result=[['Rita Ora', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Dakota Johnson', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Marcia Gay Harden', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Jamie Dornan', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Eloise Mumford', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Max Martini', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Luke Grimes', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Jennifer Ehle', 'Fifty Shades of Grey', 2015, 224710, '4.1', 'Drama'],
+                     ['Victor Rasuk', 'Fifty Shades of Grey', 2015,224710, '4.1', 'Drama'],
+                     ['Nancy Lenehan', 'Sex Tape', 2014, 86018, '5.1', 'Comedy'],
+                     ['Rob Lowe', 'Sex Tape', 2014, 86018, '5.1', 'Comedy'],
+                     ['Cameron Diaz', 'Sex Tape', 2014, 86018, '5.1', 'Comedy'],
+                     ['Rob Corddry', 'Sex Tape', 2014, 86018, '5.1', 'Comedy'],
+                     ['Jason Segel', 'Sex Tape', 2014, 86018, '5.1', 'Comedy'],
+                     ['Ellie Kemper', 'Sex Tape', 2014, 86018, '5.1', 'Comedy']]
 )
 
 
@@ -103,8 +103,8 @@ young_actors_played_with_cameron_diaz_query = QueryInfo(
              RETURN a, m.title""",
     description='Which young actors played along side Cameron Diaz?',
     max_run_time_ms=5,
-    expected_result=[['Nicolette Pierini', '16', 'Annie'],
-                     ['Kate Upton', '27', 'The Other Woman']]
+    expected_result=[['Nicolette Pierini', 16, 'Annie'],
+                     ['Kate Upton', 27, 'The Other Woman']]
 )
 
 
@@ -114,13 +114,13 @@ actors_played_with_cameron_diaz_and_younger_than_her_query = QueryInfo(
              RETURN a, m.title order by a.name""",
     description='Which actors played along side Cameron Diaz and are younger then her?',
     max_run_time_ms=7,
-    expected_result=[['Jason Segel', '39', 'Sex Tape'],
-                     ['Ellie Kemper', '39', 'Sex Tape'],
-                     ['Nicolette Pierini', '16', 'Annie'],
-                     ['Rose Byrne', '40', 'Annie'],
-                     ['Kate Upton', '27', 'The Other Woman'],
-                     ['Nicki Minaj', '37', 'The Other Woman'],
-                     ['Taylor Kinney', '38', 'The Other Woman']]
+    expected_result=[['Jason Segel', 39, 'Sex Tape'],
+                     ['Ellie Kemper', 39, 'Sex Tape'],
+                     ['Nicolette Pierini', 16, 'Annie'],
+                     ['Rose Byrne', 40, 'Annie'],
+                     ['Kate Upton', 27, 'The Other Woman'],
+                     ['Nicki Minaj', 37, 'The Other Woman'],
+                     ['Taylor Kinney', 38, 'The Other Woman']]
 )
 
 
@@ -138,7 +138,7 @@ how_many_movies_cameron_diaz_played_query = QueryInfo(
              RETURN Cameron.name, COUNT(m.title)""",
     description='In how many movies did Cameron Diaz played?',
     max_run_time_ms=1.2,
-    expected_result=[['Cameron Diaz', '3']]
+    expected_result=[['Cameron Diaz', 3]]
 )
 
 
@@ -149,16 +149,16 @@ find_ten_oldest_actors_query = QueryInfo(
              LIMIT 10""",
     description='10 Oldest actors?',
     max_run_time_ms=4.5,
-    expected_result=[['Vincent Price', '108'],
-                     ['George Kennedy', '94'],
-                     ['Cloris Leachman', '93'],
-                     ['John Cullum', '89'],
-                     ['Lois Smith', '89'],
-                     ['Robert Duvall', '88'],
-                     ['Olympia Dukakis', '88'],
-                     ['Ellen Burstyn', '87'],
-                     ['Michael Caine', '86'],
-                     ['Judi Dench', '85']]
+    expected_result=[['Vincent Price', 108],
+                     ['George Kennedy', 94],
+                     ['Cloris Leachman', 93],
+                     ['John Cullum', 89],
+                     ['Lois Smith', 89],
+                     ['Robert Duvall', 88],
+                     ['Olympia Dukakis', 88],
+                     ['Ellen Burstyn', 87],
+                     ['Michael Caine', 86],
+                     ['Judi Dench', 85]]
 )
 
 actors_over_85_index_scan = QueryInfo(
@@ -168,15 +168,15 @@ actors_over_85_index_scan = QueryInfo(
              ORDER BY a.age, a.name""",
     description='Actors over 85 on indexed property?',
     max_run_time_ms=1.5,
-    expected_result=[['Michael Caine', '86'],
-                     ['Ellen Burstyn', '87'],
-                     ['Robert Duvall', '88'],
-                     ['Olympia Dukakis', '88'],
-                     ['Lois Smith', '89'],
-                     ['John Cullum', '89'],
-                     ['Cloris Leachman', '93'],
-                     ['George Kennedy', '94'],
-                     ['Vincent Price', '108']]
+    expected_result=[['Michael Caine', 86],
+                     ['Ellen Burstyn', 87],
+                     ['Robert Duvall', 88],
+                     ['Olympia Dukakis', 88],
+                     ['Lois Smith', 89],
+                     ['John Cullum', 89],
+                     ['Cloris Leachman', 93],
+                     ['George Kennedy', 94],
+                     ['Vincent Price', 108]]
 )
 
 eighties_movies_index_scan = QueryInfo(
@@ -187,8 +187,8 @@ eighties_movies_index_scan = QueryInfo(
              ORDER BY m.year""",
     description='Multiple filters on indexed property?',
     max_run_time_ms=1.5,
-    expected_result=[['The Evil Dead', '1981'],
-                     ['Vincent', '1982']]
+    expected_result=[['The Evil Dead', 1981],
+                     ['Vincent', 1982]]
 )
 
 find_titles_starting_with_american_query = QueryInfo(

--- a/demo/social/social_queries.py
+++ b/demo/social/social_queries.py
@@ -41,8 +41,8 @@ relation_type_counts = QueryInfo(
     query="""MATCH ()-[e]->() RETURN TYPE(e) as relation_type, COUNT(e) as num_relations ORDER BY relation_type, num_relations""",
     description='Returns each relation type in the graph and its count.',
     max_run_time_ms=0.4,
-    expected_result=[['friend', '13'],
-                     ['visited', '35']]
+    expected_result=[['friend', 13],
+                     ['visited', 35]]
 )
 
 subset_of_people = QueryInfo(
@@ -89,7 +89,7 @@ friends_of_friends_single_and_over_30_query = QueryInfo(
              RETURN fof""",
     description='Friends of friends who are single and over 30?',
     max_run_time_ms=0.25,
-    expected_result=[['Noam Nativ', '34', 'male', 'single']]
+    expected_result=[['Noam Nativ', 34, 'male', 'single']]
 )
 
 friends_of_friends_visited_amsterdam_and_single_query = QueryInfo(
@@ -123,7 +123,7 @@ friends_older_than_me_query = QueryInfo(
              RETURN f.name, f.age""",
     description='Friends who are older than me?',
     max_run_time_ms=0.25,
-    expected_result=[['Omri Traub', '33']]
+    expected_result=[['Omri Traub', 33]]
 )
 
 friends_age_difference_query = QueryInfo(
@@ -132,12 +132,12 @@ friends_age_difference_query = QueryInfo(
              ORDER BY age_diff desc""",
     description='Age difference between me and each of my friends.',
     max_run_time_ms=0.35,
-    expected_result=[['Boaz Arad', '1'],
-                     ['Omri Traub', '1'],
-                     ['Ailon Velger', '0'],
-                     ['Tal Doron', '0'],
-                     ['Ori Laslo', '0'],
-                     ['Alon Fital', '0']]
+    expected_result=[['Boaz Arad', 1],
+                     ['Omri Traub', 1],
+                     ['Ailon Velger', 0],
+                     ['Tal Doron', 0],
+                     ['Ori Laslo', 0],
+                     ['Alon Fital', 0]]
 )
 
 how_many_countries_each_friend_visited_query = QueryInfo(
@@ -147,11 +147,11 @@ how_many_countries_each_friend_visited_query = QueryInfo(
              LIMIT 10""",
     description='Count for each friend how many countires he or she been to?',
     max_run_time_ms=0.3,
-    expected_result=[['Alon Fital', '3'],
-                     ['Omri Traub', '3'],
-                     ['Tal Doron', '3'],
-                     ['Ori Laslo', '3'],
-                     ['Boaz Arad', '2']]
+    expected_result=[['Alon Fital', 3],
+                     ['Omri Traub', 3],
+                     ['Tal Doron', 3],
+                     ['Ori Laslo', 3],
+                     ['Boaz Arad', 2]]
 )
 
 happy_birthday_query = QueryInfo(
@@ -167,7 +167,7 @@ friends_age_statistics_query = QueryInfo(
              RETURN ME.name, count(f.name), sum(f.age), avg(f.age), min(f.age), max(f.age)""",
     description='Friends age statistics.',
     max_run_time_ms=0.2,
-    expected_result=[['Roi Lipman', '6', '198', '33', '32', '34']]
+    expected_result=[['Roi Lipman', 6, '198', '33', 32, 34]]
 )
 
 visit_purpose_of_each_country_i_visited_query = QueryInfo(
@@ -200,13 +200,13 @@ number_of_vacations_per_person_query = QueryInfo(
              LIMIT 6""",
     description='Count number of vacations per person?',
     max_run_time_ms=0.5,
-    expected_result=[['Noam Nativ', '3'],
-                     ['Shelly Laslo Rooz', '3'],
-                     ['Omri Traub', '3'],
-                     ['Lucy Yanfital', '2'],
-                     ['Jane Chernomorin', '2'],
-                     ['Mor Yesharim', '2'],
-                     ['Valerie Abigail Arad', '2']]
+    expected_result=[['Noam Nativ', 3],
+                     ['Shelly Laslo Rooz', 3],
+                     ['Omri Traub', 3],
+                     ['Lucy Yanfital', 2],
+                     ['Jane Chernomorin', 2],
+                     ['Mor Yesharim', 2],
+                     ['Valerie Abigail Arad', 2]]
 )
 
 all_reachable_friends_query = QueryInfo(
@@ -236,19 +236,19 @@ all_reachable_countries_query = QueryInfo(
              ORDER BY NumPathsToCountry DESC""",
     description='Find all reachable countries',
     max_run_time_ms=0.6,
-    expected_result=[['USA', '9'],
-                     ['Amsterdam', '5'],
-                     ['Greece', '4'],
-                     ['Prague', '3'],
-                     ['Germany', '2'],
-                     ['Andora', '2'],
-                     ['Japan', '2'],
-                     ['Canada', '2'],
-                     ['China', '2'],
-                     ['Kazakhstan', '1'],
-                     ['Thailand', '1'],
-                     ['Italy', '1'],
-                     ['Russia', '1']]
+    expected_result=[['USA', 9],
+                     ['Amsterdam', 5],
+                     ['Greece', 4],
+                     ['Prague', 3],
+                     ['Germany', 2],
+                     ['Andora', 2],
+                     ['Japan', 2],
+                     ['Canada', 2],
+                     ['China', 2],
+                     ['Kazakhstan', 1],
+                     ['Thailand', 1],
+                     ['Italy', 1],
+                     ['Russia', 1]]
 )
 
 reachable_countries_or_people_query = QueryInfo(
@@ -274,32 +274,32 @@ all_reachable_countries_or_people_query = QueryInfo(
              ORDER BY NumPathsToEntity DESC""",
     description='Every reachable person or country from source node',
     max_run_time_ms=0.4,
-    expected_result=[['USA', '9'],
-                     ['Amsterdam', '5'],
-                     ['Greece', '4'],
-                     ['Prague', '3'],
-                     ['Germany', '2'],
-                     ['Japan', '2'],
-                     ['Andora', '2'],
-                     ['Canada', '2'],
-                     ['China', '2'],
-                     ['Ailon Velger', '1'],
-                     ['Alon Fital', '1'],
-                     ['Gal Derriere', '1'],
-                     ['Jane Chernomorin', '1'],
-                     ['Omri Traub', '1'],
-                     ['Boaz Arad', '1'],
-                     ['Noam Nativ', '1'],
-                     ['Shelly Laslo Rooz', '1'],
-                     ['Russia', '1'],
-                     ['Valerie Abigail Arad', '1'],
-                     ['Mor Yesharim', '1'],
-                     ['Italy', '1'],
-                     ['Tal Doron', '1'],
-                     ['Thailand', '1'],
-                     ['Kazakhstan', '1'],
-                     ['Lucy Yanfital', '1'],
-                     ['Ori Laslo', '1']]
+    expected_result=[['USA', 9],
+                     ['Amsterdam', 5],
+                     ['Greece', 4],
+                     ['Prague', 3],
+                     ['Germany', 2],
+                     ['Japan', 2],
+                     ['Andora', 2],
+                     ['Canada', 2],
+                     ['China', 2],
+                     ['Ailon Velger', 1],
+                     ['Alon Fital', 1],
+                     ['Gal Derriere', 1],
+                     ['Jane Chernomorin', 1],
+                     ['Omri Traub', 1],
+                     ['Boaz Arad', 1],
+                     ['Noam Nativ', 1],
+                     ['Shelly Laslo Rooz', 1],
+                     ['Russia', 1],
+                     ['Valerie Abigail Arad', 1],
+                     ['Mor Yesharim', 1],
+                     ['Italy', 1],
+                     ['Tal Doron', 1],
+                     ['Thailand', 1],
+                     ['Kazakhstan', 1],
+                     ['Lucy Yanfital', 1],
+                     ['Ori Laslo', 1]]
 )
 
 all_reachable_entities_query = QueryInfo(
@@ -308,32 +308,32 @@ all_reachable_entities_query = QueryInfo(
              ORDER BY NumPathsToEntity DESC""",
     description='Find all reachable entities',
     max_run_time_ms=0.4,
-    expected_result=[['USA', '9'],
-                     ['Amsterdam', '5'],
-                     ['Greece', '4'],
-                     ['Prague', '3'],
-                     ['Germany', '2'],
-                     ['Japan', '2'],
-                     ['Andora', '2'],
-                     ['Canada', '2'],
-                     ['China', '2'],
-                     ['Ailon Velger', '1'],
-                     ['Alon Fital', '1'],
-                     ['Gal Derriere', '1'],
-                     ['Jane Chernomorin', '1'],
-                     ['Omri Traub', '1'],
-                     ['Boaz Arad', '1'],
-                     ['Noam Nativ', '1'],
-                     ['Shelly Laslo Rooz', '1'],
-                     ['Russia', '1'],
-                     ['Valerie Abigail Arad', '1'],
-                     ['Mor Yesharim', '1'],
-                     ['Italy', '1'],
-                     ['Tal Doron', '1'],
-                     ['Thailand', '1'],
-                     ['Kazakhstan', '1'],
-                     ['Lucy Yanfital', '1'],
-                     ['Ori Laslo', '1']]
+    expected_result=[['USA', 9],
+                     ['Amsterdam', 5],
+                     ['Greece', 4],
+                     ['Prague', 3],
+                     ['Germany', 2],
+                     ['Japan', 2],
+                     ['Andora', 2],
+                     ['Canada', 2],
+                     ['China', 2],
+                     ['Ailon Velger', 1],
+                     ['Alon Fital', 1],
+                     ['Gal Derriere', 1],
+                     ['Jane Chernomorin', 1],
+                     ['Omri Traub', 1],
+                     ['Boaz Arad', 1],
+                     ['Noam Nativ', 1],
+                     ['Shelly Laslo Rooz', 1],
+                     ['Russia', 1],
+                     ['Valerie Abigail Arad', 1],
+                     ['Mor Yesharim', 1],
+                     ['Italy', 1],
+                     ['Tal Doron', 1],
+                     ['Thailand', 1],
+                     ['Kazakhstan', 1],
+                     ['Lucy Yanfital', 1],
+                     ['Ori Laslo', 1]]
 )
 
 delete_friendships_query = QueryInfo(

--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -207,7 +207,7 @@ int __agg_countStep(AggCtx *ctx, SIValue *argv, int argc) {
 
 int __agg_countReduceNext(AggCtx *ctx) {
     __agg_countCtx *ac = Agg_FuncCtx(ctx);
-    Agg_SetResult(ctx, SI_DoubleVal(ac->count));
+    Agg_SetResult(ctx, SI_LongVal(ac->count));
     return AGG_OK;
 }
 

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -419,20 +419,8 @@ SIValue AR_DIV(SIValue *argv, int argc) {
 SIValue AR_ABS(SIValue *argv, int argc) {
     SIValue result = argv[0];
     if (!_validate_numeric(result)) return SI_NullVal();
-    switch (SI_TYPE(result)) {
-        case T_DOUBLE:
-            if (result.doubleval < 0) {
-                result.doubleval = -result.doubleval;
-            }
-            return result;
-        case T_INT64:
-            if (result.longval < 0) {
-                result.longval = -result.longval;
-            }
-            return result;
-        default:
-            return SI_NullVal();
-    }
+    if(SI_GET_NUMERIC(argv[0]) < 0) return SIValue_Multiply(argv[0], SI_LongVal(-1));
+    return argv[0];
 }
 
 SIValue AR_CEIL(SIValue *argv, int argc) {
@@ -468,7 +456,7 @@ SIValue AR_ROUND(SIValue *argv, int argc) {
 
 SIValue AR_SIGN(SIValue *argv, int argc) {
     if (!_validate_numeric(argv[0])) return SI_NullVal();
-    int64_t sign = VAL_SIGN(SI_GET_NUMERIC(argv[0]));
+    int64_t sign = SIGN(SI_GET_NUMERIC(argv[0]));
     return SI_LongVal(sign);
 }
 

--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -17,7 +17,7 @@ Record Record_New(int entries) {
 
     // First entry holds records length.
     r[0].type = REC_TYPE_HEADER;
-    r[0].value.s = SI_UintVal(entries);
+    r[0].value.s = SI_LongVal(entries);
 
     // Skip header entry.
     return r+1;
@@ -25,7 +25,7 @@ Record Record_New(int entries) {
 
 unsigned int Record_length(const Record r) {
     Entry header = RECORD_HEADER_ENTRY(r);
-    int recordLength = header.value.s.uintval;
+    int recordLength = header.value.s.longval;
     return recordLength;
 }
 

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -10,7 +10,7 @@
 #include "graph_entity.h"
 #include "../../util/rmalloc.h"
 
-SIValue *PROPERTY_NOTFOUND = &(SIValue){.intval = 0, .type = T_NULL};
+SIValue *PROPERTY_NOTFOUND = &(SIValue){.longval = 0, .type = T_NULL};
 
 /* Add a new property to entity */
 SIValue* GraphEntity_AddProperty(GraphEntity *e, Attribute_ID attr_id, SIValue value) {

--- a/src/graph/serializers/serialize_graph.c
+++ b/src/graph/serializers/serialize_graph.c
@@ -81,14 +81,8 @@ SIValue _RdbLoadSIValue(RedisModuleIO *rdb) {
      * Value */
     SIType t = RedisModule_LoadUnsigned(rdb);
     switch (t) {
-        case T_INT32:
-            return SI_IntVal(RedisModule_LoadSigned(rdb));
         case T_INT64:
             return SI_LongVal(RedisModule_LoadSigned(rdb));
-        case T_UINT:
-            return SI_UintVal(RedisModule_LoadUnsigned(rdb));
-        case T_FLOAT:
-            return SI_FloatVal(RedisModule_LoadFloat(rdb));
         case T_DOUBLE:
             return SI_DoubleVal(RedisModule_LoadDouble(rdb));
         case T_STRING:
@@ -97,7 +91,7 @@ SIValue _RdbLoadSIValue(RedisModuleIO *rdb) {
             // newly-created SIValue
             return SI_TransferStringVal(RedisModule_LoadStringBuffer(rdb, NULL));
         case T_BOOL:
-            return SI_BoolVal(RedisModule_LoadUnsigned(rdb));
+            return SI_BoolVal(RedisModule_LoadSigned(rdb));
         case T_NULL:
         default: // currently impossible
             return SI_NullVal();
@@ -186,17 +180,9 @@ void _RdbSaveSIValue(RedisModuleIO *rdb, const SIValue *v) {
      * Value */
     RedisModule_SaveUnsigned(rdb, v->type);
     switch (v->type) {
-        case T_INT32:
-            RedisModule_SaveSigned(rdb, v->intval);
-            return;
+        case T_BOOL:
         case T_INT64:
             RedisModule_SaveSigned(rdb, v->longval);
-            return;
-        case T_UINT:
-            RedisModule_SaveUnsigned(rdb, v->uintval);
-            return;
-        case T_FLOAT:
-            RedisModule_SaveFloat(rdb, v->floatval);
             return;
         case T_DOUBLE:
             RedisModule_SaveDouble(rdb, v->doubleval);
@@ -204,9 +190,6 @@ void _RdbSaveSIValue(RedisModuleIO *rdb, const SIValue *v) {
         case T_STRING:
         case T_CONSTSTRING:
             RedisModule_SaveStringBuffer(rdb, v->stringval, strlen(v->stringval) + 1);
-            return;
-        case T_BOOL:
-            RedisModule_SaveUnsigned(rdb, v->boolval);
             return;
         case T_NULL:
             return; // No data beyond the type needs to be encoded for a NULL value.

--- a/src/graph/serializers/serialize_graph.c
+++ b/src/graph/serializers/serialize_graph.c
@@ -80,17 +80,27 @@ SIValue _RdbLoadSIValue(RedisModuleIO *rdb) {
      * SIType
      * Value */
     SIType t = RedisModule_LoadUnsigned(rdb);
-    if(t & SI_NUMERIC) {
-        return SI_DoubleVal(RedisModule_LoadDouble(rdb));
-    } else if (t == T_BOOL) {
-        return SI_BoolVal(RedisModule_LoadUnsigned(rdb));
-    } else if (t == T_NULL) {
-        return SI_NullVal();
-    } else {
-        char *strVal = RedisModule_LoadStringBuffer(rdb, NULL);
-        // Transfer ownership of the heap-allocated strVal to the
-        // newly-created SIValue
-        return SI_TransferStringVal(strVal);
+    switch (t) {
+        case T_INT32:
+            return SI_IntVal(RedisModule_LoadSigned(rdb));
+        case T_INT64:
+            return SI_LongVal(RedisModule_LoadSigned(rdb));
+        case T_UINT:
+            return SI_UintVal(RedisModule_LoadUnsigned(rdb));
+        case T_FLOAT:
+            return SI_FloatVal(RedisModule_LoadFloat(rdb));
+        case T_DOUBLE:
+            return SI_DoubleVal(RedisModule_LoadDouble(rdb));
+        case T_STRING:
+        case T_CONSTSTRING: // currently impossible
+            // Transfer ownership of the heap-allocated string to the
+            // newly-created SIValue
+            return SI_TransferStringVal(RedisModule_LoadStringBuffer(rdb, NULL));
+        case T_BOOL:
+            return SI_BoolVal(RedisModule_LoadUnsigned(rdb));
+        case T_NULL:
+        default: // currently impossible
+            return SI_NullVal();
     }
 }
 
@@ -175,16 +185,33 @@ void _RdbSaveSIValue(RedisModuleIO *rdb, const SIValue *v) {
      * SIType
      * Value */
     RedisModule_SaveUnsigned(rdb, v->type);
-    if(v->type & SI_NUMERIC) {
-        RedisModule_SaveDouble(rdb, v->doubleval);
-    } else if (v->type == T_BOOL) {
-        RedisModule_SaveUnsigned(rdb, v->boolval);
-    } else if (v->type == T_NULL) {
-        return; // No data beyond the type needs to be encoded for a NULL value.
-    } else if (v->type & SI_STRING) {
-        RedisModule_SaveStringBuffer(rdb, v->stringval, strlen(v->stringval) + 1);
-    } else {
-        assert(0 && "Attempted to serialize value of invalid type.");
+    switch (v->type) {
+        case T_INT32:
+            RedisModule_SaveSigned(rdb, v->intval);
+            return;
+        case T_INT64:
+            RedisModule_SaveSigned(rdb, v->longval);
+            return;
+        case T_UINT:
+            RedisModule_SaveUnsigned(rdb, v->uintval);
+            return;
+        case T_FLOAT:
+            RedisModule_SaveFloat(rdb, v->floatval);
+            return;
+        case T_DOUBLE:
+            RedisModule_SaveDouble(rdb, v->doubleval);
+            return;
+        case T_STRING:
+        case T_CONSTSTRING:
+            RedisModule_SaveStringBuffer(rdb, v->stringval, strlen(v->stringval) + 1);
+            return;
+        case T_BOOL:
+            RedisModule_SaveUnsigned(rdb, v->boolval);
+            return;
+        case T_NULL:
+            return; // No data beyond the type needs to be encoded for a NULL value.
+        default:
+            assert(0 && "Attempted to serialize value of invalid type.");
     }
 }
 

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -30,7 +30,7 @@ int compareStrings(SIValue *a, SIValue *b) {
 }
 
 int compareNumerics(SIValue *a, SIValue *b) {
-  double diff = a->doubleval - b->doubleval;
+  double diff = SIValue_Compare(*a, *b);
   return COMPARE_RETVAL(diff);
 }
 

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -34,7 +34,7 @@ int compareNumerics(SIValue *a, SIValue *b) {
     return a->longval - b->longval;
   }
   double diff = SI_GET_NUMERIC(*a) - SI_GET_NUMERIC(*b);
-  return COMPARE_RETVAL(diff);
+  return SAFE_COMPARISON_RESULT(diff);
 }
 
 /* The index must maintain its own copy of the indexed SIValue

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -30,7 +30,10 @@ int compareStrings(SIValue *a, SIValue *b) {
 }
 
 int compareNumerics(SIValue *a, SIValue *b) {
-  double diff = SIValue_Compare(*a, *b);
+  if (a->type & b->type & T_INT64) {
+    return a->longval - b->longval;
+  }
+  double diff = SI_GET_NUMERIC(*a) - SI_GET_NUMERIC(*b);
   return COMPARE_RETVAL(diff);
 }
 

--- a/src/parser/grammar.c
+++ b/src/parser/grammar.c
@@ -2042,13 +2042,13 @@ static void yy_reduce(
         break;
       case 102: /* value ::= INTEGER */
 #line 572 "grammar.y"
-{  yylhsminor.yy189 = SI_DoubleVal(yymsp[0].minor.yy0.intval); }
+{  yylhsminor.yy189 = SI_LongVal(yymsp[0].minor.yy0.intval); }
 #line 2047 "grammar.c"
   yymsp[0].minor.yy189 = yylhsminor.yy189;
         break;
       case 103: /* value ::= DASH INTEGER */
 #line 573 "grammar.y"
-{  yymsp[-1].minor.yy189 = SI_DoubleVal(-yymsp[0].minor.yy0.intval); }
+{  yymsp[-1].minor.yy189 = SI_LongVal(-yymsp[0].minor.yy0.intval); }
 #line 2053 "grammar.c"
         break;
       case 104: /* value ::= STRING */

--- a/src/parser/grammar.c
+++ b/src/parser/grammar.c
@@ -1668,28 +1668,28 @@ static void yy_reduce(
       case 53: /* edgeLength ::= MUL INTEGER DOTDOT INTEGER */
 #line 322 "grammar.y"
 {
-	yymsp[-3].minor.yy140 = New_AST_LinkLength(yymsp[-2].minor.yy0.intval, yymsp[0].minor.yy0.intval);
+	yymsp[-3].minor.yy140 = New_AST_LinkLength(yymsp[-2].minor.yy0.longval, yymsp[0].minor.yy0.longval);
 }
 #line 1674 "grammar.c"
         break;
       case 54: /* edgeLength ::= MUL INTEGER DOTDOT */
 #line 327 "grammar.y"
 {
-	yymsp[-2].minor.yy140 = New_AST_LinkLength(yymsp[-1].minor.yy0.intval, UINT_MAX-2);
+	yymsp[-2].minor.yy140 = New_AST_LinkLength(yymsp[-1].minor.yy0.longval, UINT_MAX-2);
 }
 #line 1681 "grammar.c"
         break;
       case 55: /* edgeLength ::= MUL DOTDOT INTEGER */
 #line 332 "grammar.y"
 {
-	yymsp[-2].minor.yy140 = New_AST_LinkLength(1, yymsp[0].minor.yy0.intval);
+	yymsp[-2].minor.yy140 = New_AST_LinkLength(1, yymsp[0].minor.yy0.longval);
 }
 #line 1688 "grammar.c"
         break;
       case 56: /* edgeLength ::= MUL INTEGER */
 #line 337 "grammar.y"
 {
-	yymsp[-1].minor.yy140 = New_AST_LinkLength(yymsp[0].minor.yy0.intval, yymsp[0].minor.yy0.intval);
+	yymsp[-1].minor.yy140 = New_AST_LinkLength(yymsp[0].minor.yy0.longval, yymsp[0].minor.yy0.longval);
 }
 #line 1695 "grammar.c"
         break;
@@ -1985,7 +1985,7 @@ static void yy_reduce(
       case 92: /* skipClause ::= SKIP INTEGER */
 #line 536 "grammar.y"
 {
-	yymsp[-1].minor.yy173 = New_AST_SkipNode(yymsp[0].minor.yy0.intval);
+	yymsp[-1].minor.yy173 = New_AST_SkipNode(yymsp[0].minor.yy0.longval);
 }
 #line 1991 "grammar.c"
         break;
@@ -1999,7 +1999,7 @@ static void yy_reduce(
       case 94: /* limitClause ::= LIMIT INTEGER */
 #line 545 "grammar.y"
 {
-	yymsp[-1].minor.yy77 = New_AST_LimitNode(yymsp[0].minor.yy0.intval);
+	yymsp[-1].minor.yy77 = New_AST_LimitNode(yymsp[0].minor.yy0.longval);
 }
 #line 2005 "grammar.c"
         break;
@@ -2042,13 +2042,13 @@ static void yy_reduce(
         break;
       case 102: /* value ::= INTEGER */
 #line 572 "grammar.y"
-{  yylhsminor.yy189 = SI_LongVal(yymsp[0].minor.yy0.intval); }
+{  yylhsminor.yy189 = SI_LongVal(yymsp[0].minor.yy0.longval); }
 #line 2047 "grammar.c"
   yymsp[0].minor.yy189 = yylhsminor.yy189;
         break;
       case 103: /* value ::= DASH INTEGER */
 #line 573 "grammar.y"
-{  yymsp[-1].minor.yy189 = SI_LongVal(-yymsp[0].minor.yy0.intval); }
+{  yymsp[-1].minor.yy189 = SI_LongVal(-yymsp[0].minor.yy0.longval); }
 #line 2053 "grammar.c"
         break;
       case 104: /* value ::= STRING */

--- a/src/parser/grammar.y
+++ b/src/parser/grammar.y
@@ -320,22 +320,22 @@ edgeLength(A) ::= . {
 
 // *minHops..maxHops
 edgeLength(A) ::= MUL INTEGER(B) DOTDOT INTEGER(C). {
-	A = New_AST_LinkLength(B.intval, C.intval);
+	A = New_AST_LinkLength(B.longval, C.longval);
 }
 
 // *minHops..
 edgeLength(A) ::= MUL INTEGER(B) DOTDOT. {
-	A = New_AST_LinkLength(B.intval, UINT_MAX-2);
+	A = New_AST_LinkLength(B.longval, UINT_MAX-2);
 }
 
 // *..maxHops
 edgeLength(A) ::= MUL DOTDOT INTEGER(B). {
-	A = New_AST_LinkLength(1, B.intval);
+	A = New_AST_LinkLength(1, B.longval);
 }
 
 // *hops
 edgeLength(A) ::= MUL INTEGER(B). {
-	A = New_AST_LinkLength(B.intval, B.intval);
+	A = New_AST_LinkLength(B.longval, B.longval);
 }
 
 // *
@@ -534,7 +534,7 @@ skipClause(A) ::= . {
 	A = NULL;
 }
 skipClause(A) ::= SKIP INTEGER(B). {
-	A = New_AST_SkipNode(B.intval);
+	A = New_AST_SkipNode(B.longval);
 }
 
 %type limitClause {AST_LimitNode*}
@@ -543,7 +543,7 @@ limitClause(A) ::= . {
 	A = NULL;
 }
 limitClause(A) ::= LIMIT INTEGER(B). {
-	A = New_AST_LimitNode(B.intval);
+	A = New_AST_LimitNode(B.longval);
 }
 
 %type unwindClause {AST_UnwindNode*}
@@ -569,8 +569,8 @@ relation(A) ::= NE. { A = NE; }
 %type value {SIValue}
 
 // raw value tokens - int / string / float
-value(A) ::= INTEGER(B). {  A = SI_LongVal(B.intval); }
-value(A) ::= DASH INTEGER(B). {  A = SI_LongVal(-B.intval); }
+value(A) ::= INTEGER(B). {  A = SI_LongVal(B.longval); }
+value(A) ::= DASH INTEGER(B). {  A = SI_LongVal(-B.longval); }
 value(A) ::= STRING(B). {  A = SI_ConstStringVal(B.strval); }
 value(A) ::= FLOAT(B). {  A = SI_DoubleVal(B.dval); }
 value(A) ::= DASH FLOAT(B). {  A = SI_DoubleVal(-B.dval); }

--- a/src/parser/grammar.y
+++ b/src/parser/grammar.y
@@ -569,8 +569,8 @@ relation(A) ::= NE. { A = NE; }
 %type value {SIValue}
 
 // raw value tokens - int / string / float
-value(A) ::= INTEGER(B). {  A = SI_DoubleVal(B.intval); }
-value(A) ::= DASH INTEGER(B). {  A = SI_DoubleVal(-B.intval); }
+value(A) ::= INTEGER(B). {  A = SI_LongVal(B.intval); }
+value(A) ::= DASH INTEGER(B). {  A = SI_LongVal(-B.intval); }
 value(A) ::= STRING(B). {  A = SI_ConstStringVal(B.strval); }
 value(A) ::= FLOAT(B). {  A = SI_DoubleVal(B.dval); }
 value(A) ::= DASH FLOAT(B). {  A = SI_DoubleVal(-B.dval); }

--- a/src/parser/lex.yy.c
+++ b/src/parser/lex.yy.c
@@ -7,8 +7,8 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -46,7 +46,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -54,7 +53,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -85,63 +83,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -158,15 +154,16 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
+    #define YY_LINENO_REWIND_TO(ptr)
     
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
@@ -181,7 +178,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -196,12 +192,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -224,7 +220,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -252,7 +248,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -263,7 +259,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -271,11 +266,11 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -284,82 +279,78 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 54
 #define YY_END_OF_BUFFER 55
 /* This struct is not used in this scanner,
@@ -369,7 +360,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[144] =
+static const flex_int16_t yy_accept[144] =
     {   0,
         0,    0,   55,   54,   52,   53,   54,   54,   54,   30,
        31,   49,   50,   29,   44,   47,   48,   26,   45,   43,
@@ -389,7 +380,7 @@ static yyconst flex_int16_t yy_accept[144] =
        27,   11,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -421,7 +412,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[71] =
+static const YY_CHAR yy_meta[71] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    2,    1,    1,    2,    1,    1,    1,    1,    2,
@@ -432,7 +423,7 @@ static yyconst flex_int32_t yy_meta[71] =
         2,    2,    2,    2,    2,    2,    2,    1,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[149] =
+static const flex_int16_t yy_base[149] =
     {   0,
         0,    0,  207,  291,  202,  291,  185,   66,   67,  291,
       291,  291,  291,  291,  183,   59,  291,   62,  291,   64,
@@ -452,7 +443,7 @@ static yyconst flex_int16_t yy_base[149] =
       219,    0,  291,  282,  284,   83,  286,  288
     } ;
 
-static yyconst flex_int16_t yy_def[149] =
+static const flex_int16_t yy_def[149] =
     {   0,
       143,    1,  143,  143,  143,  143,  143,  144,  145,  143,
       143,  143,  143,  143,  143,  143,  143,  143,  143,  143,
@@ -472,7 +463,7 @@ static yyconst flex_int16_t yy_def[149] =
       146,  146,    0,  143,  143,  143,  143,  143
     } ;
 
-static yyconst flex_int16_t yy_nxt[362] =
+static const flex_int16_t yy_nxt[362] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,   22,   23,
@@ -516,7 +507,7 @@ static yyconst flex_int16_t yy_nxt[362] =
       143
     } ;
 
-static yyconst flex_int16_t yy_chk[362] =
+static const flex_int16_t yy_chk[362] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -592,7 +583,8 @@ int yycolumn = 1;
     tok.pos = yycolumn; \
     tok.s = yytext;
     /* tok.s = strdup(yytext); */
-#line 596 "lex.yy.c"
+#line 587 "lex.yy.c"
+#line 588 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -608,36 +600,36 @@ int yycolumn = 1;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -645,35 +637,43 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
-    static void yyunput (int c,char *buf_ptr  );
+#ifndef YY_NO_UNPUT
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -681,7 +681,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( yytext, yyleng, 1, yyout )
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -692,7 +692,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -705,7 +705,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -760,7 +760,7 @@ extern int yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -770,15 +770,10 @@ extern int yylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     
-#line 20 "lexer.l"
-
-
-#line 781 "lex.yy.c"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -799,13 +794,19 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 20 "lexer.l"
+
+
+#line 808 "lex.yy.c"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
@@ -821,7 +822,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -831,9 +832,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 144 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 291 );
@@ -992,7 +993,7 @@ case 26:
 YY_RULE_SETUP
 #line 53 "lexer.l"
 {
-  tok.intval = atoi(yytext); 
+  tok.intval = atol(yytext);
   return INTEGER;
 }
 	YY_BREAK
@@ -1146,7 +1147,7 @@ YY_RULE_SETUP
 #line 97 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 1150 "lex.yy.c"
+#line 1151 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1224,7 +1225,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1277,6 +1278,7 @@ case YY_STATE_EOF(INITIAL):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -1288,9 +1290,9 @@ case YY_STATE_EOF(INITIAL):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1319,7 +1321,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1332,21 +1334,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1355,11 +1357,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1387,7 +1390,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1401,12 +1404,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1422,14 +1428,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1439,9 +1445,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 144 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1454,10 +1460,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1467,17 +1473,19 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 144 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 143);
 
-	return yy_is_jam ? 0 : yy_current_state;
+		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
+#ifndef YY_NO_UNPUT
+
+    static void yyunput (int c, char * yy_bp )
 {
-	register char *yy_cp;
+	char *yy_cp;
     
     yy_cp = (yy_c_buf_p);
 
@@ -1487,10 +1495,10 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		int number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1499,7 +1507,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1511,6 +1519,8 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -1536,7 +1546,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1553,13 +1563,13 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
 						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
@@ -1597,11 +1607,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1629,7 +1639,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1657,7 +1667,7 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -1666,13 +1676,13 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1691,15 +1701,11 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -1709,7 +1715,7 @@ extern int isatty (int );
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1752,7 +1758,7 @@ extern int isatty (int );
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1783,7 +1789,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1802,7 +1808,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -1820,15 +1826,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -1837,7 +1843,7 @@ static void yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
@@ -1857,7 +1863,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -1867,23 +1873,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -1896,28 +1902,29 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -1926,7 +1933,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -1942,9 +1949,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -1972,7 +1979,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -1995,7 +2002,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -2010,29 +2017,29 @@ char *yyget_text  (void)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        yyout = out_str ;
+        yyout = _out_str ;
 }
 
 int yyget_debug  (void)
@@ -2040,9 +2047,9 @@ int yyget_debug  (void)
         return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
@@ -2051,10 +2058,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2063,8 +2070,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2079,7 +2086,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2100,18 +2107,19 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2121,11 +2129,12 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2133,18 +2142,17 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 97 "lexer.l"
-
 
 
 /**

--- a/src/parser/lex.yy.c
+++ b/src/parser/lex.yy.c
@@ -993,7 +993,7 @@ case 26:
 YY_RULE_SETUP
 #line 53 "lexer.l"
 {
-  tok.intval = atol(yytext);
+  tok.longval = atol(yytext);
   return INTEGER;
 }
 	YY_BREAK

--- a/src/parser/lexer.l
+++ b/src/parser/lexer.l
@@ -51,7 +51,7 @@ int yycolumn = 1;
 }
 
 [0-9]+    {
-  tok.intval = atol(yytext);
+  tok.longval = atol(yytext);
   return INTEGER;
 }
 

--- a/src/parser/lexer.l
+++ b/src/parser/lexer.l
@@ -51,7 +51,7 @@ int yycolumn = 1;
 }
 
 [0-9]+    {
-  tok.intval = atoi(yytext); 
+  tok.intval = atol(yytext);
   return INTEGER;
 }
 

--- a/src/parser/token.h
+++ b/src/parser/token.h
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 
 typedef struct {
-  int64_t intval;
+  int64_t longval;
   double dval;
   char *strval;
   char *s;  // token string

--- a/src/resultset/resultset.c
+++ b/src/resultset/resultset.c
@@ -48,23 +48,14 @@ static void _ResultSet_ReplyWithScalar(RedisModuleCtx *ctx, const SIValue v) {
         case T_CONSTSTRING:
             RedisModule_ReplyWithStringBuffer(ctx, v.stringval, strlen(v.stringval));
             return;
-        case T_INT32:
-            RedisModule_ReplyWithLongLong(ctx, v.intval);
-            return;
         case T_INT64:
             RedisModule_ReplyWithLongLong(ctx, v.longval);
-            return;
-        case T_UINT:
-            RedisModule_ReplyWithLongLong(ctx, v.uintval);
-            return;
-        case T_FLOAT:
-            _ResultSet_ReplyWithRoundedDouble(ctx, (double)v.floatval);
             return;
         case T_DOUBLE:
             _ResultSet_ReplyWithRoundedDouble(ctx, v.doubleval);
             return;
         case T_BOOL:
-            if (v.boolval == true) RedisModule_ReplyWithStringBuffer(ctx, "true", 4);
+            if (v.longval != 0) RedisModule_ReplyWithStringBuffer(ctx, "true", 4);
             else RedisModule_ReplyWithStringBuffer(ctx, "false", 5);
             return;
         case T_NULL:

--- a/src/value.c
+++ b/src/value.c
@@ -194,15 +194,13 @@ SIValue SIValue_Divide(const SIValue a, const SIValue b) {
 int SIValue_Compare(const SIValue a, const SIValue b) {
   /* In order to be comparable, both SIValues must be strings,
    * booleans, or numerics. */
-  SIType t = a.type ^ b.type;
-  if (!t) {
-    // Both inputs have the same type
+  if (a.type == b.type) {
     switch (a.type) {
       case T_INT64:
       case T_BOOL:
         return a.longval - b.longval;
       case T_DOUBLE:
-        return COMPARE_RETVAL(a.doubleval - b.doubleval);
+        return SAFE_COMPARISON_RESULT(a.doubleval - b.doubleval);
       case T_STRING:
       case T_CONSTSTRING:
         // Both inputs are strings of the same SIType
@@ -211,12 +209,14 @@ int SIValue_Compare(const SIValue a, const SIValue b) {
         // Both pointers were of an incomparable type, like a pointer
         return DISJOINT;
     }
-  } else if (t == SI_NUMERIC) {
-    // Both inputs are of different numeric types
+  }
+
+  // The inputs have different SITypes - compare them if they
+  // are both numerics or both strings of differing types
+  if (SI_TYPE(a) & SI_NUMERIC && SI_TYPE(b) & SI_NUMERIC) {
     double diff = SI_GET_NUMERIC(a) - SI_GET_NUMERIC(b);
-    return COMPARE_RETVAL(diff);
-  } else if (t == SI_STRING) {
-    // Both inputs are strings of differing SITypes
+    return SAFE_COMPARISON_RESULT(diff);
+  } else if (SI_TYPE(a) & SI_STRING && SI_TYPE(b) & SI_STRING) {
     return strcmp(a.stringval, b.stringval);
   }
 

--- a/src/value.c
+++ b/src/value.c
@@ -14,7 +14,9 @@
 #include <assert.h>
 #include "util/rmalloc.h"
 
-SIValue SI_IntVal(int i) { return (SIValue){.intval = i, .type = T_INT32}; }
+SIValue SI_IntVal(int i) {
+  return (SIValue){.intval = i, .type = T_INT32};
+}
 
 SIValue SI_LongVal(int64_t i) {
   return (SIValue){.longval = i, .type = T_INT64};
@@ -252,6 +254,33 @@ int SIValue_ToDouble(const SIValue *v, double *d) {
   }
 }
 
+int SIValue_ToLong(const SIValue *v, int64_t *l) {
+  switch (v->type) {
+      case T_INT64:
+          *l = v->longval;
+          return 1;
+      case T_DOUBLE:
+          *l = (long)v->doubleval;
+          return 1;
+      case T_INT32:
+          *l = (long)v->intval;
+          return 1;
+      case T_UINT:
+          *l = (long)v->uintval;
+          return 1;
+      case T_FLOAT:
+          *l = (long)v->floatval;
+          return 1;
+      case T_BOOL:
+          *l = (long)v->boolval;
+          return 1;
+
+      default:
+          // cannot convert!
+          return 0;
+  }
+}
+
 int SIValue_ConvertToDouble(SIValue *v) {
   switch (v->type) {
     case T_DOUBLE:
@@ -278,6 +307,35 @@ int SIValue_ConvertToDouble(SIValue *v) {
   }
 
   v->type = T_DOUBLE;
+  return 1;
+}
+
+int SIValue_ConvertToLong(SIValue *v) {
+  switch (v->type) {
+    case T_INT64:
+      return 1;
+    case T_DOUBLE:
+      v->longval = (long)v->doubleval;
+      break;
+    case T_INT32:
+      v->longval = (long)v->intval;
+      break;
+    case T_UINT:
+      v->longval = (long)v->uintval;
+      break;
+    case T_FLOAT:
+      v->longval = (long)v->floatval;
+      break;
+    case T_BOOL:
+      v->longval = (long)v->boolval;
+      break;
+
+    default:
+      // cannot convert!
+      return 0;
+  }
+
+  v->type = T_INT64;
   return 1;
 }
 
@@ -337,6 +395,7 @@ int SIValue_Compare(SIValue a, SIValue b) {
   // Use strcmp if values are string types
   if (a.type & SI_STRING) return strcmp(a.stringval, b.stringval);
 
+  // TODO improve logic for numeric comparisons
   // Attempt to cast both values to doubles
   double tmp_a, tmp_b;
   if (SIValue_ToDouble(&a, &tmp_a) && SIValue_ToDouble(&b, &tmp_b)) {

--- a/src/value.c
+++ b/src/value.c
@@ -14,20 +14,8 @@
 #include <assert.h>
 #include "util/rmalloc.h"
 
-SIValue SI_IntVal(int i) {
-  return (SIValue){.intval = i, .type = T_INT32};
-}
-
 SIValue SI_LongVal(int64_t i) {
   return (SIValue){.longval = i, .type = T_INT64};
-}
-
-SIValue SI_UintVal(u_int64_t i) {
-  return (SIValue){.uintval = i, .type = T_UINT};
-}
-
-SIValue SI_FloatVal(float f) {
-  return (SIValue){.floatval = f, .type = T_FLOAT};
 }
 
 SIValue SI_DoubleVal(double d) {
@@ -35,11 +23,11 @@ SIValue SI_DoubleVal(double d) {
 }
 
 SIValue SI_NullVal(void) {
-  return (SIValue){.intval = 0, .type = T_NULL};
+  return (SIValue){.longval = 0, .type = T_NULL};
 }
 
 SIValue SI_BoolVal(int b) {
-  return (SIValue) {.boolval = b, .type = T_BOOL};
+  return (SIValue) {.longval = b, .type = T_BOOL};
 }
 
 SIValue SI_PtrVal(void* v) {
@@ -83,108 +71,6 @@ inline int SIValue_IsNullPtr(SIValue *v) {
   return v == NULL || v->type == T_NULL;
 }
 
-int _parseInt(SIValue *v, char *str) {
-
-  errno = 0; /* To distinguish success/failure after call */
-  char *endptr = NULL;
-  long long int val = strtoll(str, &endptr, 10);
-
-  if (errno == ERANGE || (errno != 0 && val == 0)) {
-    perror("strtoll");
-    return 0;
-  }
-
-  if (endptr == str) {
-    fprintf(stderr, "No digits were found\n");
-    return 0;
-  }
-
-  switch (v->type) {
-  case T_INT32:
-    v->intval = val;
-    break;
-  case T_INT64:
-    v->longval = val;
-    break;
-  case T_UINT:
-    v->uintval = (u_int64_t)val;
-    break;
-  default:
-    return 0;
-  }
-  return 1;
-}
-
-int _parseBool(SIValue *v, char *str) {
-  int len = strlen(str);
-  if ((len == 1 && !strcmp("1", str)) ||
-      (len == 4 && !strcasecmp("true", str))) {
-    v->boolval = 1;
-    return 1;
-  }
-
-  if ((len == 1 && !strcmp("0", str)) ||
-      (len == 5 && !strcasecmp("false", str))) {
-    v->boolval = 0;
-    return 1;
-  }
-  return 0;
-}
-
-int _parseFloat(SIValue *v, char *str) {
-  errno = 0; /* To distinguish success/failure after call */
-  char *endptr = NULL;
-  double val = strtod(str, &endptr);
-
-  /* Check for various possible errors */
-  if (errno != 0 || (endptr == str && val == 0)) {
-    return 0;
-  }
-
-  switch (v->type) {
-  case T_FLOAT:
-    v->floatval = (float)val;
-    break;
-  case T_DOUBLE:
-    v->doubleval = val;
-    break;
-  default:
-    return 0;
-    break;
-  }
-
-  return 1;
-}
-
-int SI_ParseValue(SIValue *v, char *str) {
-  switch (v->type) {
-
-  case T_STRING:
-    v->stringval = rm_strdup(str);
-    break;
-  case T_CONSTSTRING:
-    v->stringval = str;
-    break;
-  case T_INT32:
-  case T_INT64:
-  case T_UINT:
-    return _parseInt(v, str);
-
-  case T_BOOL:
-    return _parseBool(v, str);
-
-  case T_FLOAT:
-  case T_DOUBLE:
-    return _parseFloat(v, str);
-
-  case T_NULL:
-  default:
-    return 0;
-  }
-
-  return 1;
-}
-
 int SIValue_ToString(SIValue v, char *buf, size_t len) {
   int bytes_written = 0;
 
@@ -194,30 +80,14 @@ int SIValue_ToString(SIValue v, char *buf, size_t len) {
     strncpy(buf, v.stringval, len);
     bytes_written = strlen(buf);
     break;
-  case T_INT32:
-    bytes_written = snprintf(buf, len, "%d", v.intval);
-    break;
   case T_INT64:
     bytes_written = snprintf(buf, len, "%lld", (long long)v.longval);
     break;
-  case T_UINT:
-    bytes_written = snprintf(buf, len, "%llu", (long long)v.uintval);
-    break;
   case T_BOOL:
-    bytes_written = snprintf(buf, len, "%s", v.boolval ? "true" : "false");
-    break;
-
-  case T_FLOAT:
-    bytes_written = snprintf(buf, len, "%f", v.floatval);
+    bytes_written = snprintf(buf, len, "%s", v.longval ? "true" : "false");
     break;
   case T_DOUBLE:
     bytes_written = snprintf(buf, len, "%f", v.doubleval);
-    break;
-  case T_INF:
-    bytes_written = snprintf(buf, len, "+inf");
-    break;
-  case T_NEGINF:
-    bytes_written = snprintf(buf, len, "-inf");
     break;
   case T_NULL:
   default:
@@ -233,110 +103,14 @@ int SIValue_ToDouble(const SIValue *v, double *d) {
     *d = v->doubleval;
     return 1;
   case T_INT64:
-    *d = (double)v->longval;
-    return 1;
-  case T_INT32:
-    *d = (double)v->intval;
-    return 1;
-  case T_UINT:
-    *d = (double)v->uintval;
-    return 1;
-  case T_FLOAT:
-    *d = (double)v->floatval;
-    return 1;
   case T_BOOL:
-    *d = (double)v->boolval;
+    *d = (double)v->longval;
     return 1;
 
   default:
     // cannot convert!
     return 0;
   }
-}
-
-int SIValue_ToLong(const SIValue *v, int64_t *l) {
-  switch (v->type) {
-      case T_INT64:
-          *l = v->longval;
-          return 1;
-      case T_DOUBLE:
-          *l = (long)v->doubleval;
-          return 1;
-      case T_INT32:
-          *l = (long)v->intval;
-          return 1;
-      case T_UINT:
-          *l = (long)v->uintval;
-          return 1;
-      case T_FLOAT:
-          *l = (long)v->floatval;
-          return 1;
-      case T_BOOL:
-          *l = (long)v->boolval;
-          return 1;
-
-      default:
-          // cannot convert!
-          return 0;
-  }
-}
-
-int SIValue_ConvertToDouble(SIValue *v) {
-  switch (v->type) {
-    case T_DOUBLE:
-      return 1;
-    case T_INT64:
-      v->doubleval = (double)v->longval;
-      break;
-    case T_INT32:
-      v->doubleval = (double)v->intval;
-      break;
-    case T_UINT:
-      v->doubleval = (double)v->uintval;
-      break;
-    case T_FLOAT:
-      v->doubleval = (double)v->floatval;
-      break;
-    case T_BOOL:
-      v->doubleval = (double)v->boolval;
-      break;
-
-    default:
-      // cannot convert!
-      return 0;
-  }
-
-  v->type = T_DOUBLE;
-  return 1;
-}
-
-int SIValue_ConvertToLong(SIValue *v) {
-  switch (v->type) {
-    case T_INT64:
-      return 1;
-    case T_DOUBLE:
-      v->longval = (long)v->doubleval;
-      break;
-    case T_INT32:
-      v->longval = (long)v->intval;
-      break;
-    case T_UINT:
-      v->longval = (long)v->uintval;
-      break;
-    case T_FLOAT:
-      v->longval = (long)v->floatval;
-      break;
-    case T_BOOL:
-      v->longval = (long)v->boolval;
-      break;
-
-    default:
-      // cannot convert!
-      return 0;
-  }
-
-  v->type = T_INT64;
-  return 1;
 }
 
 SIValue SIValue_FromString(const char *s) {
@@ -385,30 +159,68 @@ size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *b
   return offset;
 }
 
-int SIValue_Compare(SIValue a, SIValue b) {
-  // In order to be comparable, both SIValues must be strings,
-  // booleans, or numerics
-  if (!SI_COMPARABLE(a, b)) {
-    return DISJOINT;
+SIValue SIValue_Add(const SIValue a, const SIValue b) {
+  /* Only construct an integer return if both operands are integers. */
+  if (a.type & b.type & T_INT64) {
+    return SI_LongVal(a.longval + b.longval);
   }
+  /* Return a double representation. */
+  return SI_DoubleVal(SI_GET_NUMERIC(a) + SI_GET_NUMERIC(b));
+}
 
-  // Use strcmp if values are string types
-  if (a.type & SI_STRING) return strcmp(a.stringval, b.stringval);
+SIValue SIValue_Subtract(const SIValue a, const SIValue b) {
+  /* Only construct an integer return if both operands are integers. */
+  if (a.type & b.type & T_INT64) {
+    return SI_LongVal(a.longval - b.longval);
+  }
+  /* Return a double representation. */
+  return SI_DoubleVal(SI_GET_NUMERIC(a) - SI_GET_NUMERIC(b));
+}
 
-  // TODO improve logic for numeric comparisons
-  // Attempt to cast both values to doubles
-  double tmp_a, tmp_b;
-  if (SIValue_ToDouble(&a, &tmp_a) && SIValue_ToDouble(&b, &tmp_b)) {
-    /* Both values are numeric, and both now have double representations.
-     * TODO worry about precision and overflows. This approach will
-     * not be adequate if we have high-value longs, especially.
-     * TODO Special values like inf, -inf, and NaN will compare properly
-     * here, but may not satisfy the prescribed openCypher sort order. */
-    double diff = tmp_a - tmp_b;
+SIValue SIValue_Multiply(const SIValue a, const SIValue b) {
+  /* Only construct an integer return if both operands are integers. */
+  if (a.type & b.type & T_INT64) {
+    return SI_LongVal(a.longval * b.longval);
+  }
+  /* Return a double representation. */
+  return SI_DoubleVal(SI_GET_NUMERIC(a) * SI_GET_NUMERIC(b));
+}
+
+SIValue SIValue_Divide(const SIValue a, const SIValue b) {
+  /* Always perform floating-point division. */
+  return SI_DoubleVal(SI_GET_NUMERIC(a) / (double)SI_GET_NUMERIC(b));
+}
+
+int SIValue_Compare(const SIValue a, const SIValue b) {
+  /* In order to be comparable, both SIValues must be strings,
+   * booleans, or numerics. */
+  SIType t = a.type ^ b.type;
+  if (!t) {
+    // Both inputs have the same type
+    switch (a.type) {
+      case T_INT64:
+      case T_BOOL:
+        return a.longval - b.longval;
+      case T_DOUBLE:
+        return COMPARE_RETVAL(a.doubleval - b.doubleval);
+      case T_STRING:
+      case T_CONSTSTRING:
+        // Both inputs are strings of the same SIType
+        return strcmp(a.stringval, b.stringval);
+      default:
+        // Both pointers were of an incomparable type, like a pointer
+        return DISJOINT;
+    }
+  } else if (t == SI_NUMERIC) {
+    // Both inputs are of different numeric types
+    double diff = SI_GET_NUMERIC(a) - SI_GET_NUMERIC(b);
     return COMPARE_RETVAL(diff);
+  } else if (t == SI_STRING) {
+    // Both inputs are strings of differing SITypes
+    return strcmp(a.stringval, b.stringval);
   }
 
-  // Reachable if values are of the same incomparable type, such as NULL
+  // Inputs are not comparable
   return DISJOINT;
 }
 
@@ -436,32 +248,6 @@ int SIValue_Order(const SIValue a, const SIValue b) {
 
   // We can reach here if both values are NULL, in which case no order is imposed.
   return 0;
-}
-
-void SIValue_Print(FILE *outstream, SIValue *v) {
-  switch (v->type) {
-    case T_STRING:
-    case T_CONSTSTRING:
-      fprintf(outstream, "%s", v->stringval);
-      break;
-    case T_INT32:
-      fprintf(outstream, "%d", v->intval);
-      break;
-    case T_INT64:
-      fprintf(outstream, "%lld", (long long)v->longval);
-      break;
-    case T_UINT:
-      fprintf(outstream, "%u", v->intval);
-      break;
-    case T_FLOAT:
-      fprintf(outstream, "%lf", v->floatval);
-      break;
-    case T_DOUBLE:
-      fprintf(outstream, "%lf", v->doubleval);
-      break;
-    default:
-      break;
-  }
 }
 
 void SIValue_Free(SIValue *v) {

--- a/src/value.h
+++ b/src/value.h
@@ -23,7 +23,7 @@ typedef enum {
   // T_INT32 = 0x002, // unused
   T_INT64 = 0x004,
   // T_UINT = 0x008, // unused
-  T_BOOL = 0x010, // Instance of T_INT64
+  T_BOOL = 0x010, // shares 'longval' representation in SIValue union
   // T_FLOAT = 0x020, // unused
   T_DOUBLE = 0x040,
   T_PTR = 0x080,
@@ -38,12 +38,14 @@ typedef enum {
  * assigning it a type. */
 #define SI_GET_NUMERIC(v) ((v).type == T_DOUBLE ? (v).doubleval : (v).longval)
 
+/* Build an integer return value for a comparison routine in the style of strcmp.
+ * This is necessary to construct safe returns when the delta between
+ * two values is < 1.0 (and would thus be rounded to 0). */
+#define SAFE_COMPARISON_RESULT(a) SIGN(a)
+
 /* Returns 1 if argument is positive, -1 if argument is negative,
- * and 0 if argument is zero (matching the return style of the strcmp family).
- * This is necessary to construct safe integer returns when the delta between
- * two double values is < 1.0 (and would thus be rounded to 0). */
-#define COMPARE_RETVAL(a) VAL_SIGN(a)
-#define VAL_SIGN(a) ((a) > 0) - ((a) < 0)
+ * and 0 if argument is zero.*/
+#define SIGN(a) ((a) > 0) - ((a) < 0)
 
 #define DISJOINT INT_MAX
 

--- a/src/value.h
+++ b/src/value.h
@@ -48,7 +48,8 @@ typedef enum {
  * and 0 if argument is zero (matching the return style of the strcmp family).
  * This is necessary to construct safe integer returns when the delta between
  * two double values is < 1.0 (and would thus be rounded to 0). */
-#define COMPARE_RETVAL(a) ((a) > 0) - ((a) < 0)
+#define COMPARE_RETVAL(a) VAL_SIGN(a)
+#define VAL_SIGN(a) ((a) > 0) - ((a) < 0)
 
 #define DISJOINT INT_MAX
 
@@ -95,8 +96,14 @@ int SIValue_ToString(SIValue v, char *buf, size_t len);
 /* Try to read a value as a double. */
 int SIValue_ToDouble(const SIValue *v, double *d);
 
+/* Try to read a value as an int64. */
+int SIValue_ToLong(const SIValue *v, int64_t *l);
+
 /* Try to internally convert a value to a double. */
 int SIValue_ConvertToDouble(SIValue *v);
+
+/* Try to internally convert a value to an int64. */
+int SIValue_ConvertToLong(SIValue *v);
 
 /* Try to parse a value by string. */
 SIValue SIValue_FromString(const char *s);
@@ -115,6 +122,8 @@ int SIValue_Compare(SIValue a, SIValue b);
  * to Cypher's comparability property if applicable, and its orderability property if not.
  * Under Cypher's orderability, where string < boolean < numeric < NULL. */
 int SIValue_Order(const SIValue a, const SIValue b);
+
+int SIValue_Add(SIValue *lhs, const SIValue *rhs);
 
 void SIValue_Print(FILE *outstream, SIValue *v);
 

--- a/src/value.h
+++ b/src/value.h
@@ -20,29 +20,23 @@
 typedef enum {
   T_NULL = 0,
   T_STRING = 0x001,
-  T_INT32 = 0x002,
+  // T_INT32 = 0x002, // unused
   T_INT64 = 0x004,
-  T_UINT = 0x008,
-  T_BOOL = 0x010,
-  T_FLOAT = 0x020,
+  // T_UINT = 0x008, // unused
+  T_BOOL = 0x010, // Instance of T_INT64
+  // T_FLOAT = 0x020, // unused
   T_DOUBLE = 0x040,
   T_PTR = 0x080,
   T_CONSTSTRING = 0x100,
-
-  // special types for +inf and -inf on all types:
-  T_INF = 0x200,
-  T_NEGINF = 0x400,
-
 } SIType;
 
 #define SI_STRING (T_STRING | T_CONSTSTRING)
-#define SI_NUMERIC (T_INT32 | T_INT64 | T_UINT | T_FLOAT | T_DOUBLE)
+#define SI_NUMERIC (T_INT64 | T_DOUBLE)
 #define SI_TYPE(value) (value).type
 
-/* Returns true if aVal and bVal are of the same type, are both string types, or are both numeric types. */
-#define SI_COMPARABLE(aVal, bVal) ((aVal).type == (bVal).type || \
-		(((aVal).type & SI_NUMERIC) && (bVal).type & SI_NUMERIC) || \
-		(((aVal).type & SI_STRING) && (bVal).type & SI_STRING))
+/* Retrieve the numeric associated with an SIValue without explicitly
+ * assigning it a type. */
+#define SI_GET_NUMERIC(v) ((v).type == T_DOUBLE ? (v).doubleval : (v).longval)
 
 /* Returns 1 if argument is positive, -1 if argument is negative,
  * and 0 if argument is zero (matching the return style of the strcmp family).
@@ -55,12 +49,8 @@ typedef enum {
 
 typedef struct {
   union {
-    int32_t intval;
     int64_t longval;
-    u_int64_t uintval;
-    float floatval;
     double doubleval;
-    int boolval;
     char *stringval;
     void* ptrval;
   };
@@ -68,10 +58,7 @@ typedef struct {
 } SIValue;
 
 /* Functions to construct an SIValue from a specific input type. */
-SIValue SI_IntVal(int i);
 SIValue SI_LongVal(int64_t i);
-SIValue SI_UintVal(u_int64_t i);
-SIValue SI_FloatVal(float f);
 SIValue SI_DoubleVal(double d);
 SIValue SI_NullVal(void);
 SIValue SI_BoolVal(int b);
@@ -87,23 +74,11 @@ SIValue SI_ShallowCopy(SIValue v);         // Don't duplicate any inputs
 int SIValue_IsNull(SIValue v);
 int SIValue_IsNullPtr(SIValue *v);
 
-/* Try to parse a value by string. The value's type should be set to
-* anything other than T_NULL, to force strict parsing. */
-int SI_ParseValue(SIValue *v, char *str);
-
 int SIValue_ToString(SIValue v, char *buf, size_t len);
 
-/* Try to read a value as a double. */
+/* Try to read a value as a double.
+ * TODO Only used by agg_funcs, consider refactoring. */
 int SIValue_ToDouble(const SIValue *v, double *d);
-
-/* Try to read a value as an int64. */
-int SIValue_ToLong(const SIValue *v, int64_t *l);
-
-/* Try to internally convert a value to a double. */
-int SIValue_ConvertToDouble(SIValue *v);
-
-/* Try to internally convert a value to an int64. */
-int SIValue_ConvertToLong(SIValue *v);
 
 /* Try to parse a value by string. */
 SIValue SIValue_FromString(const char *s);
@@ -114,18 +89,25 @@ size_t SIValue_StringConcatLen(SIValue* strings, unsigned int string_count);
 /* Concats strings as a comma separated string. */
 size_t SIValue_StringConcat(SIValue* strings, unsigned int string_count, char *buf, size_t buf_len);
 
+/* Arithmetic operators for numeric SIValues.
+ * The caller is responsible for ensuring that the arguments
+ * are numeric types.
+ * If both arguments are integer types, the result is as well,
+ * otherwise a double is returned. */
+SIValue SIValue_Add(const SIValue a, const SIValue b);
+SIValue SIValue_Subtract(const SIValue a, const SIValue b);
+SIValue SIValue_Multiply(const SIValue a, const SIValue b);
+/* SIValue_Divide always returns a double value. */
+SIValue SIValue_Divide(const SIValue a, const SIValue b);
+
 /* Compares two SIValues and returns a value similar to strcmp, or
  * the macro DISJOINT if the values were not of comparable types. */
-int SIValue_Compare(SIValue a, SIValue b);
+int SIValue_Compare(const SIValue a, const SIValue b);
 
 /* Return a strcmp-style integer value indicating which value is greater according
  * to Cypher's comparability property if applicable, and its orderability property if not.
  * Under Cypher's orderability, where string < boolean < numeric < NULL. */
 int SIValue_Order(const SIValue a, const SIValue b);
-
-int SIValue_Add(SIValue *lhs, const SIValue *rhs);
-
-void SIValue_Print(FILE *outstream, SIValue *v);
 
 /* Free an SIValue's internal property if that property is a heap allocation owned
  * by this object. This is only the case when the type is T_STRING. */

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -118,7 +118,7 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (charlie { name: 'Charlie Sheen' }) RETURN charlie"""
         actual_result = redis_graph.query(query)
         expected_result = [['charlie.age', 'charlie.name', 'charlie.lastname'],
-                           ['11', 'Charlie Sheen', 'Sheen']]
+                           [11, 'Charlie Sheen', 'Sheen']]
         assert(actual_result.result_set == expected_result)
 
     # Update new entity
@@ -134,7 +134,7 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (tamara:ACTOR { name: 'Tamara Tunie' }) RETURN tamara"""
         actual_result = redis_graph.query(query)
         expected_result = [['tamara.name', 'tamara.age'],
-                           ['Tamara Tunie', '59']]
+                           ['Tamara Tunie', 59]]
         assert(actual_result.result_set == expected_result)
 
     # Create a single edge and additional two nodes.
@@ -160,7 +160,7 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (franklin:ACTOR { name: 'Franklin Cover' })-[r:ACTED_IN {rate:5.9, date:1998}]->(almostHeroes:MOVIE) RETURN franklin.name, franklin.age, r.rate, r.date"""
         actual_result = redis_graph.query(query)
         expected_result = [['franklin.name', 'franklin.age', 'r.rate', 'r.date'],
-                           ['Franklin Cover', None, '5.9', '1998']]
+                           ['Franklin Cover', None, '5.9', 1998]]
         assert(actual_result.result_set == expected_result)
     
 
@@ -182,10 +182,10 @@ class GraphMergeFlowTest(FlowTestsBase):
         query = """MATCH (p:person) RETURN p"""
         actual_result = redis_graph.query(query)
         expected_result = [['p.age', 'p.newprop'],
-                           ['31', '100'],
-                           ['31', '100'],
-                           ['31', '100'],
-                           ['31', '100']]
+                           [31, 100],
+                           [31, 100],
+                           [31, 100],
+                           [31, 100]]
         assert(actual_result.result_set == expected_result)
 
     # Update multiple nodes

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -201,7 +201,7 @@ class GraphPersistency(FlowTestsBase):
         read_query = """MATCH (a)-[e]->(b) RETURN e, a, b"""
         actual_result = graph.query(read_query)
         expected_result = [['e.val', 'a.name', 'b.name'],
-                           ['1', 'src', 'dest']]
+                           [1, 'src', 'dest']]
         assert(actual_result.result_set == expected_result)
 
         # Overwrite the existing edge
@@ -212,7 +212,7 @@ class GraphPersistency(FlowTestsBase):
         actual_result = graph.query(read_query)
         # TODO This is the expected current behavior, subject to later change.
         expected_result = [['e.val', 'a.name', 'b.name'],
-                           ['2', 'src', 'dest']]
+                           [2, 'src', 'dest']]
         assert(actual_result.result_set == expected_result)
 
         # Save RDB & Load from RDB

--- a/tests/flow/test_value_comparisons.py
+++ b/tests/flow/test_value_comparisons.py
@@ -53,7 +53,7 @@ class ValueComparisonTest(FlowTestsBase):
                     ['str2'],
                     ['false'],
                     ['true'],
-                    ['5'],
+                    [5],
                     ['10.5'],
                     [None]]
         assert(actual_result.result_set[1:] == expected)

--- a/tests/tck/utils/assertions.py
+++ b/tests/tck/utils/assertions.py
@@ -45,10 +45,12 @@ def assert_resultset_content(resultset, expected):
             # Strip value from single quotes.
             actualCell = actualRow[cellIdx]
             expectedCell = expectedRow[cellIdx]
-            actualCell = actualCell.replace("'", "")
-            actualCell = actualCell.replace('"', "")
-            expectedCell = expectedCell.replace("'", "")
-            expectedCell = expectedCell.replace('"', "")
+            if isinstance(actualCell, basestring):
+                actualCell = actualCell.replace("'", "")
+                actualCell = actualCell.replace('"', "")
+            if isinstance(expectedCell, basestring):
+                expectedCell = expectedCell.replace("'", "")
+                expectedCell = expectedCell.replace('"', "")
 
             # Cast to integer if possible.
             if is_number_tryexcept(actualCell):

--- a/tests/unit/test_aggregate_functions.cpp
+++ b/tests/unit/test_aggregate_functions.cpp
@@ -60,7 +60,7 @@ TEST_F(AggregateTest, CountTest) {
   for (int i = 0; i < num_values; i ++) AR_EXP_Aggregate(arExp, r);
   AR_EXP_Reduce(arExp);
   result = AR_EXP_Evaluate(arExp, r);
-  ASSERT_EQ(result.doubleval, num_values);
+  ASSERT_EQ(result.longval, num_values);
   AR_EXP_Free(arExp);
 }
 
@@ -95,7 +95,7 @@ TEST_F(AggregateTest, PartialCountTest) {
 
   // The counted result should be half the number of inserted entities,
   // as the null values are ignored.
-  ASSERT_EQ(res.doubleval, num_values / 2);
+  ASSERT_EQ(res.longval, num_values / 2);
   AR_EXP_Free(arExp);
 }
 

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -46,7 +46,37 @@ void _test_string(const AR_ExpNode *exp, const char *expected) {
 
 void _test_ar_func(AR_ExpNode *root, SIValue expected, const Record r) {
   SIValue res = AR_EXP_Evaluate(root, r);
-  ASSERT_EQ(res.doubleval, expected.doubleval);
+  // Compare values directly if their types are equal
+  if (SI_TYPE(res) == SI_TYPE(expected)) {
+    switch (SI_TYPE(res)) {
+      case T_FLOAT:
+        ASSERT_EQ(res.floatval, expected.floatval);
+        return;
+      case T_DOUBLE:
+        ASSERT_EQ(res.doubleval, expected.doubleval);
+        return;
+      case T_INT32:
+        ASSERT_EQ(res.intval, expected.intval);
+        return;
+      case T_INT64:
+        ASSERT_EQ(res.longval, expected.longval);
+        return;
+      case T_UINT:
+        ASSERT_EQ(res.uintval, expected.uintval);
+        return;
+      case T_NULL:
+        return; // Type check was sufficient
+      default:
+        FAIL() << "Tried to compare disjoint types";
+    }
+  }
+
+  // Compare double representations if types don't match
+  double expected_double;
+  double res_double;
+  ASSERT_TRUE(SIValue_ToDouble(&expected, &expected_double));
+  ASSERT_TRUE(SIValue_ToDouble(&res, &res_double));
+  ASSERT_EQ(res_double, expected_double);
 }
 
 AR_ExpNode* _exp_from_query(const char *query) {
@@ -80,28 +110,28 @@ TEST_F(ArithmeticTest, ExpressionTest) {
   arExp = _exp_from_query(query);
   result = AR_EXP_Evaluate(arExp, r);
   AR_EXP_Free(arExp);
-  ASSERT_EQ(result.doubleval, 1);
+  ASSERT_EQ(result.longval , 1);
 
   /* 1+2*3 */
   query = "RETURN 1+2*3";
   arExp = _exp_from_query(query);
   result = AR_EXP_Evaluate(arExp, r);
   AR_EXP_Free(arExp);
-  ASSERT_EQ(result.doubleval, 7);
+  ASSERT_EQ(result.longval, 7);
 
   /* 1 + 1 + 1 + 1 + 1 + 1 */
   query = "RETURN 1 + 1 + 1 + 1 + 1 + 1";
   arExp = _exp_from_query(query);
   result = AR_EXP_Evaluate(arExp, r);
   AR_EXP_Free(arExp);
-  ASSERT_EQ(result.doubleval, 6);
+  ASSERT_EQ(result.longval, 6);
 
   /* ABS(-5 + 2 * 1) */
   query = "RETURN ABS(-5 + 2 * 1)";
   arExp = _exp_from_query(query);
   result = AR_EXP_Evaluate(arExp, r);
   AR_EXP_Free(arExp);
-  ASSERT_EQ(result.doubleval, 3);
+  ASSERT_EQ(result.longval, 3);
 
   /* 'a' + 'b' */
   query = "RETURN 'a' + 'b'";
@@ -115,14 +145,14 @@ TEST_F(ArithmeticTest, ExpressionTest) {
   arExp = _exp_from_query(query);
   result = AR_EXP_Evaluate(arExp, r);
   AR_EXP_Free(arExp);
-  ASSERT_TRUE(strcmp(result.stringval, "3.000000a2.0000001.000000") == 0);
+  ASSERT_TRUE(strcmp(result.stringval, "3a21") == 0);
 
   /* 2 * 2 + 'a' + 3 * 3 */
   query = "RETURN 2 * 2 + 'a' + 3 * 3";
   arExp = _exp_from_query(query);
   result = AR_EXP_Evaluate(arExp, r);
   AR_EXP_Free(arExp);
-  ASSERT_TRUE(strcmp(result.stringval, "4.000000a9.000000") == 0);
+  ASSERT_TRUE(strcmp(result.stringval, "4a9") == 0);
 }
 
 TEST_F(ArithmeticTest, AggregateTest) {
@@ -167,21 +197,21 @@ TEST_F(ArithmeticTest, AbsTest) {
   /* ABS(1) */
   query = "RETURN ABS(1)";
   arExp = _exp_from_query(query);
-  SIValue expected = SI_DoubleVal(1);
+  SIValue expected = SI_LongVal(1);
   _test_ar_func(arExp, expected, r);
   AR_EXP_Free(arExp);
 
   /* ABS(-1) */
   query = "RETURN ABS(-1)";
   arExp = _exp_from_query(query);
-  expected = SI_DoubleVal(1);
+  expected = SI_LongVal(1);
   _test_ar_func(arExp, expected, r);
   AR_EXP_Free(arExp);
 
   /* ABS(0) */
   query = "RETURN ABS(0)";
   arExp = _exp_from_query(query);
-  expected = SI_DoubleVal(0);
+  expected = SI_LongVal(0);
   _test_ar_func(arExp, expected, r);
   AR_EXP_Free(arExp);
   
@@ -314,21 +344,21 @@ TEST_F(ArithmeticTest, SignTest) {
   /* SIGN(0) */
   query = "RETURN SIGN(0)";
   arExp = _exp_from_query(query);
-  expected = SI_DoubleVal(0);
+  expected = SI_LongVal(0);
   _test_ar_func(arExp, expected, r);
   AR_EXP_Free(arExp);
 
   /* SIGN(-1) */
   query = "RETURN SIGN(-1)";
   arExp = _exp_from_query(query);
-  expected = SI_DoubleVal(-1);
+  expected = SI_LongVal(-1);
   _test_ar_func(arExp, expected, r);
   AR_EXP_Free(arExp);
 
   /* SIGN(1) */
   query = "RETURN SIGN(1)";
   arExp = _exp_from_query(query);
-  expected = SI_DoubleVal(1);
+  expected = SI_LongVal(1);
   _test_ar_func(arExp, expected, r);
   AR_EXP_Free(arExp);
 

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -49,20 +49,11 @@ void _test_ar_func(AR_ExpNode *root, SIValue expected, const Record r) {
   // Compare values directly if their types are equal
   if (SI_TYPE(res) == SI_TYPE(expected)) {
     switch (SI_TYPE(res)) {
-      case T_FLOAT:
-        ASSERT_EQ(res.floatval, expected.floatval);
-        return;
       case T_DOUBLE:
         ASSERT_EQ(res.doubleval, expected.doubleval);
         return;
-      case T_INT32:
-        ASSERT_EQ(res.intval, expected.intval);
-        return;
       case T_INT64:
         ASSERT_EQ(res.longval, expected.longval);
-        return;
-      case T_UINT:
-        ASSERT_EQ(res.uintval, expected.uintval);
         return;
       case T_NULL:
         return; // Type check was sufficient

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -46,28 +46,15 @@ void _test_string(const AR_ExpNode *exp, const char *expected) {
 
 void _test_ar_func(AR_ExpNode *root, SIValue expected, const Record r) {
   SIValue res = AR_EXP_Evaluate(root, r);
-  // Compare values directly if their types are equal
-  if (SI_TYPE(res) == SI_TYPE(expected)) {
-    switch (SI_TYPE(res)) {
-      case T_DOUBLE:
-        ASSERT_EQ(res.doubleval, expected.doubleval);
-        return;
-      case T_INT64:
-        ASSERT_EQ(res.longval, expected.longval);
-        return;
-      case T_NULL:
-        return; // Type check was sufficient
-      default:
-        FAIL() << "Tried to compare disjoint types";
-    }
+  if (SI_TYPE(res) == T_NULL && SI_TYPE(expected) == T_NULL) {
+    // NULLs implicitly match
+    return;
+  } else if (SI_TYPE(res) & SI_NUMERIC && SI_TYPE(expected) & SI_NUMERIC) {
+    // Compare numerics by internal value
+    ASSERT_EQ(SI_GET_NUMERIC(res), SI_GET_NUMERIC(expected));
+  } else {
+    FAIL() << "Tried to compare disjoint types";
   }
-
-  // Compare double representations if types don't match
-  double expected_double;
-  double res_double;
-  ASSERT_TRUE(SIValue_ToDouble(&expected, &expected_double));
-  ASSERT_TRUE(SIValue_ToDouble(&res, &res_double));
-  ASSERT_EQ(res_double, expected_double);
 }
 
 AR_ExpNode* _exp_from_query(const char *query) {

--- a/tests/unit/test_record.cpp
+++ b/tests/unit/test_record.cpp
@@ -30,16 +30,16 @@ class RecordTest: public ::testing::Test {
 TEST_F(RecordTest, RecordToString) {
     Record r = Record_New(6);
     SIValue v_string = SI_ConstStringVal("Hello");
-    SIValue v_int = SI_IntVal(-24);
-    SIValue v_uint = SI_UintVal(24);
-    SIValue v_float = SI_FloatVal(0.314);
+    SIValue v_int = SI_LongVal(-24);
+    SIValue v_uint = SI_LongVal(24);
+    SIValue v_double = SI_DoubleVal(0.314);
     SIValue v_null = SI_NullVal();
     SIValue v_bool = SI_BoolVal(1);
 
     Record_AddScalar(r, 0, v_string);
     Record_AddScalar(r, 1, v_int);
     Record_AddScalar(r, 2, v_uint);
-    Record_AddScalar(r, 3, v_float);
+    Record_AddScalar(r, 3, v_double);
     Record_AddScalar(r, 4, v_null);
     Record_AddScalar(r, 5, v_bool);
 


### PR DESCRIPTION
Instead of converting integer tokens to SIValue doubles, they will now be SIValue longs (signed 8-byte integers).

The serialization routines for SIValues have been extended, but this does not break backwards compatibility.

One caveat regarding user experience: queries that formerly produced doubles may now produce longs, and the result sets will be smarter about representing integers.

I think that the `value.h` and `arithmetic_expression.h` comparison and arithmetic routines have potential for optimization, which is a point we should revisit later.