### PR TITLE
Increment RDB encoding version

### DIFF
--- a/src/graph/serializers/graphcontext_type.h
+++ b/src/graph/serializers/graphcontext_type.h
@@ -12,7 +12,7 @@
 
 extern RedisModuleType *GraphContextRedisModuleType;
 
-#define GRAPHCONTEXT_TYPE_ENCODING_VERSION 2
+#define GRAPHCONTEXT_TYPE_ENCODING_VERSION 3
 
 /* Commands related to the redis Graph registration */
 int GraphContextType_Register(RedisModuleCtx *ctx);


### PR DESCRIPTION
An addendum to #357, since older versions of RedisGraph won't be able to load RDB files created after that change (users won't be able to downgrade).

The resulting failure text is:
`Failed loading Graph, RedisGraph version (10013) is not forward compatible.`

It might be more sensible to make this change as part of a version bump.