### PR TITLE
Compact replies send string map, header + records, then statistics

### DIFF
--- a/src/resultset/resultset.c
+++ b/src/resultset/resultset.c
@@ -30,14 +30,50 @@ EmitRecordFunc _ResultSet_SetReplyFormatter(bool compact) {
     return ResultSet_EmitVerboseRecord;
 }
 
+static void _ResultSet_ReplyWithStringMapping(RedisModuleCtx *ctx) {
+    /* TODO The string mapping in its entirety is only required if the user has
+     * requested any full entities.
+     * Similarly, no or few label/reltype strings may be necessary depending on
+     * what entity types the query requests and whether it provides labels.
+     * This whole area should be refactored as soon as possible. */
+    GraphContext *gc = GraphContext_GetFromTLS();
+
+    int prop_string_count = array_len(gc->string_mapping);
+    uint label_count = array_len(gc->node_schemas);
+    uint reltype_count = array_len(gc->relation_schemas);
+
+    // TODO if the query introduces new strings, we will be incapable of returning them
+    RedisModule_ReplyWithArray(ctx, prop_string_count + label_count + reltype_count);
+    for (int i = 0; i < prop_string_count; i ++) {
+        const char *prop = gc->string_mapping[i];
+        RedisModule_ReplyWithStringBuffer(ctx, prop, strlen(prop));
+    }
+
+    for (uint i = 0; i < label_count; i ++) {
+        const char *label = gc->node_schemas[i]->name;
+        RedisModule_ReplyWithStringBuffer(ctx, label, strlen(label));
+    }
+
+    for (uint i = 0; i < reltype_count; i ++) {
+        const char *reltype = gc->relation_schemas[i]->name;
+        RedisModule_ReplyWithStringBuffer(ctx, reltype, strlen(reltype));
+    }
+}
+
 // Prepare replay.
 static void _ResultSet_SetupReply(ResultSet *set) {
-    // Reply will contain string mapping if we're issuing a compact reply,
-    // then resultset + statistics (in that order) in either case.
-    int top_level_replies = set->compact ? 3 : 2;
-    RedisModule_ReplyWithArray(set->ctx, top_level_replies);
+    // Send the string mapping, if required, as the first response
+    if (set->compact) {
+        // Compact replies will contain 3 top-level replies
+        RedisModule_ReplyWithArray(set->ctx, 3);
+        // The first element is the the string mapping
+        _ResultSet_ReplyWithStringMapping(set->ctx);
+    } else {
+        // Verbose replies will only contain the result set and statistics
+        RedisModule_ReplyWithArray(set->ctx, 2);
+    }
 
-    // We don't know at this point the number of records, we're about to return.
+    // We don't know at this point the number of records we're about to return.
     RedisModule_ReplyWithArray(set->ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 }
 
@@ -86,36 +122,6 @@ static void _ResultSet_ReplayStats(RedisModuleCtx* ctx, ResultSet* set) {
     }
 }
 
-static void _ResultSet_ReplyWithStringMapping(RedisModuleCtx *ctx) {
-    /* TODO The string mapping in its entirety is only required if the user has
-     * requested any full entities.
-     * Similarly, no or few label/reltype strings may be necessary depending on
-     * what entity types the query requests and whether it provides labels.
-     * This whole area should be refactored as soon as possible. */
-    GraphContext *gc = GraphContext_GetFromTLS();
-    int prop_string_count = array_len(gc->string_mapping);
-
-    uint label_count = array_len(gc->node_schemas);
-    uint reltype_count = array_len(gc->relation_schemas);
-
-    // TODO if the query introduces new strings, we will be incapable of returning them
-    RedisModule_ReplyWithArray(ctx, prop_string_count + label_count + reltype_count);
-    for (int i = 0; i < prop_string_count; i ++) {
-        const char *prop = gc->string_mapping[i];
-        RedisModule_ReplyWithStringBuffer(ctx, prop, strlen(prop));
-    }
-
-    for (uint i = 0; i < label_count; i ++) {
-        const char *label = gc->node_schemas[i]->name;
-        RedisModule_ReplyWithStringBuffer(ctx, label, strlen(label));
-    }
-
-    for (uint i = 0; i < reltype_count; i ++) {
-        const char *reltype = gc->relation_schemas[i]->name;
-        RedisModule_ReplyWithStringBuffer(ctx, reltype, strlen(reltype));
-    }
-}
-
 static Column* _NewColumn(char *name, char *alias) {
     Column* column = rm_malloc(sizeof(Column));
     column->name = name;
@@ -130,13 +136,10 @@ void static _Column_Free(Column* column) {
     rm_free(column);
 }
 
-void ResultSet_CreateHeader(ResultSet *resultset, const AST *ast) {    
+void ResultSet_CreateHeader(ResultSet *resultset, const AST *ast) {
 
     if(!ast->returnNode) return;
     assert(resultset->header == NULL && resultset->recordCount == 0);
-
-    // Send the string mapping, if required, as the first response
-    if (resultset->compact) _ResultSet_ReplyWithStringMapping(resultset->ctx);
 
     ResultSetHeader* header = rm_malloc(sizeof(ResultSetHeader));
     header->columns_len = 0;


### PR DESCRIPTION
Format:
```
$ redis-cli GRAPH.QUERY imdb "MATCH (a) RETURN a LIMIT 1" --compact
1)  1) "name"
    2) "age"
    3) "title"
    4) "year"
    5) "votes"
    6) "rating"
    7) "genre"
    8) "actor"
    9) "movie"
   10) "act"
2) 1) 1) "a"
   2) 1) 1) (integer) 0
         2) 1) (integer) 7
         3) 1) 1) (integer) 0
               2) (integer) 2
               3) "Graham McTavish"
            2) 1) (integer) 1
               2) (integer) 3
               3) (integer) 58
3) 1) "Query internal execution time: 0.539020 milliseconds"
```