### PR TITLE
Include column's entity type in compact headers

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -58,7 +58,7 @@ static ResultSet* _prepare_resultset(RedisModuleCtx *ctx, AST **ast, bool compac
     // The last AST will contain the return clause, if one is specified
     AST *final_ast = ast[array_len(ast)-1];
     ResultSet *set = NewResultSet(final_ast, ctx, compact);
-    ResultSet_CreateHeader(set, final_ast);
+    ResultSet_CreateHeader(set, ast);
     return set;
 }
 

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -476,6 +476,20 @@ void AST_MapAliasToID(AST *ast, AST_WithNode *prevWithClause) {
   TrieMap_Free(definedEntities, TrieMap_NOP_CB);
 }
 
+TrieMap* AST_CollectEntityReferences(AST **ast_arr) {
+  TrieMap *alias_references = NewTrieMap();
+
+  uint ast_count = array_len(ast_arr);
+  for (uint i = 0; i < ast_count; i ++) {
+      const AST *ast = ast_arr[i];
+      // Get unique aliases from clauses that can introduce nodes and edges.
+      MatchClause_DefinedEntities(ast->matchNode, alias_references);
+      CreateClause_DefinedEntities(ast->createNode, alias_references);
+      // TODO May need to collect alias redefinitions from WITH clauses
+  }
+  return alias_references;
+}
+
 // Returns a triemap of all identifiers defined by ast.
 TrieMap* AST_Identifiers(const AST *ast) {
   TrieMap *identifiers = NewTrieMap();

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -61,6 +61,9 @@ void AST_MapAliasToID(AST *ast, AST_WithNode *prevWithClause);
 // Returns a triemap of all identifiers defined by ast.
 TrieMap* AST_Identifiers(const AST *ast);
 
+// Returns a triemap of AST_GraphEntity references from clauses that can specify nodes or edges.
+TrieMap* AST_CollectEntityReferences(AST **ast);
+
 // Checks if AST represent a read only query.
 bool AST_ReadOnly(AST **ast);
 

--- a/src/resultset/resultset.h
+++ b/src/resultset/resultset.h
@@ -35,7 +35,7 @@ typedef struct {
 
 ResultSet* NewResultSet(AST* ast, RedisModuleCtx *ctx, bool compact);
 
-void ResultSet_CreateHeader(ResultSet* set, const AST *ast);
+void ResultSet_CreateHeader(ResultSet* set, AST **ast);
 
 int ResultSet_AddRecord(ResultSet* set, Record r);
 

--- a/src/resultset/resultset_formatters.h
+++ b/src/resultset/resultset_formatters.h
@@ -6,9 +6,18 @@
 
 #pragma once
 
+#include "resultset_header.h"
 #include "../redismodule.h"
 #include "../execution_plan/record.h"
 #include "../graph/graphcontext.h"
+#include "../graph/query_graph.h"
+
+typedef enum {
+    COLUMN_UNKNOWN,
+    COLUMN_SCALAR,
+    COLUMN_NODE,
+    COLUMN_RELATION,
+} ColumnTypeUser;
 
 typedef enum {
     PROPERTY_UNKNOWN,
@@ -42,3 +51,8 @@ void ResultSet_EmitVerboseRecord(RedisModuleCtx *ctx, GraphContext *gc, const Re
 // Formatter for compact (client-parsed) replies
 void ResultSet_EmitCompactRecord(RedisModuleCtx *ctx, GraphContext *gc, const Record r, unsigned int numcols);
 
+// Formatter for verbose header reply
+void ResultSet_ReplyWithVerboseHeader(RedisModuleCtx *ctx, const ResultSetHeader *header);
+
+// Formatter for compact header reply
+void ResultSet_ReplyWithCompactHeader(RedisModuleCtx *ctx, const ResultSetHeader *header, TrieMap *entities);

--- a/src/resultset/resultset_replyverbose.c
+++ b/src/resultset/resultset_replyverbose.c
@@ -146,3 +146,16 @@ void ResultSet_EmitVerboseRecord(RedisModuleCtx *ctx, GraphContext *gc, const Re
         }
     }
 }
+
+// Emit the alias or descriptor for each column in the header.
+void ResultSet_ReplyWithVerboseHeader(RedisModuleCtx *ctx, const ResultSetHeader *header) {
+    RedisModule_ReplyWithArray(ctx, header->columns_len);
+    for(int i = 0; i < header->columns_len; i++) {
+        Column *c = header->columns[i];
+        if(c->alias) {
+            RedisModule_ReplyWithStringBuffer(ctx, c->alias, strlen(c->alias));
+        } else {
+            RedisModule_ReplyWithStringBuffer(ctx, c->name, strlen(c->name));
+        }
+    }
+}


### PR DESCRIPTION
This is not as clean a solution as I'd like, but currently the only places to retrieve the data of entity types in the user query are from the individual AST clauses or from the QueryGraph.

Verbose format:
```
$ redis-cli GRAPH.QUERY social "MATCH (a)-[e:visited]->(b) RETURN a, e, b.name LIMIT 1"
1) 1) 1) "a"
      2) "e"
      3) "b.name"
   2) 1) 1) 1) "id"
            2) (integer) 0
         2) 1) "labels"
            2) 1) "person"
         3) 1) "properties"
            2) 1) 1) "name"
                  2) "Boaz Arad"
               2) 1) "age"
                  2) (integer) 31
               3) 1) "gender"
                  2) "male"
               4) 1) "status"
                  2) "married"
      2) 1) 1) "id"
            2) (integer) 38
         2) 1) "type"
            2) "visited"
         3) 1) "src_node"
            2) (integer) 0
         4) 1) "dest_node"
            2) (integer) 16
         5) 1) "properties"
            2) 1) 1) "purpose"
                  2) "both"
      3) "Amsterdam"
2) 1) "Query internal execution time: 26.699824 milliseconds"
```
Compact format:
```
$ redis-cli GRAPH.QUERY social "MATCH (a)-[e:visited]->(b) RETURN a, e, b.name LIMIT 1" --compact
1) 1) "name"
   2) "age"
   3) "gender"
   4) "status"
   5) "purpose"
   6) "person"
   7) "country"
   8) "friend"
   9) "visited"
2) 1) 1) 1) "a"
         2) (integer) 2
      2) 1) "e"
         2) (integer) 3
      3) 1) "b.name"
         2) (integer) 1
   2) 1) 1) (integer) 0
         2) 1) (integer) 5
         3) 1) 1) (integer) 0
               2) (integer) 2
               3) "Boaz Arad"
            2) 1) (integer) 1
               2) (integer) 3
               3) (integer) 31
            3) 1) (integer) 2
               2) (integer) 2
               3) "male"
            4) 1) (integer) 3
               2) (integer) 2
               3) "married"
      2) 1) (integer) 38
         2) (integer) 0
         3) (integer) 16
         4) (integer) 8
         5) 1) 1) (integer) 4
               2) (integer) 2
               3) "both"
      3) 1) (integer) 2
         2) "Amsterdam"
3) 1) "Query internal execution time: 56.951172 milliseconds"
```
In the compact header enum, 1 is scalar, 2 is node, and 3 is relation.

I expect that the WITH clause will require additional handling.