### PR TITLE
node by id seek execution plan operation

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -232,12 +232,7 @@ OpBase* ExecutionPlan_LocateOp(OpBase *root, OPType type) {
 
 void ExecutionPlan_Taps(OpBase *root, OpBase ***taps) {
     if(root == NULL) return;
-    int t = OPType_ALL_NODE_SCAN |
-            OPType_NODE_BY_LABEL_SCAN |
-            OPType_INDEX_SCAN |
-            OPType_NODE_BY_ID_SEEK;
-
-    if(root->type & t) *taps = array_append(*taps, root);
+    if(root->type & OP_SCAN) *taps = array_append(*taps, root);
 
     for(int i = 0; i < root->childCount; i++) {
         ExecutionPlan_Taps(root->children[i], taps);

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -230,6 +230,20 @@ OpBase* ExecutionPlan_LocateOp(OpBase *root, OPType type) {
     return NULL;
 }
 
+void ExecutionPlan_Taps(OpBase *root, OpBase ***taps) {
+    if(root == NULL) return;
+    int t = OPType_ALL_NODE_SCAN |
+            OPType_NODE_BY_LABEL_SCAN |
+            OPType_INDEX_SCAN |
+            OPType_NODE_BY_ID_SEEK;
+
+    if(root->type & t) *taps = array_append(*taps, root);
+
+    for(int i = 0; i < root->childCount; i++) {
+        ExecutionPlan_Taps(root->children[i], taps);
+    }
+}
+
 OpBase* ExecutionPlan_Locate_References(OpBase *root, Vector *references) {
     OpBase *op = NULL;    
     Vector *temp = _ExecutionPlan_Locate_References(root, &op, references);

--- a/src/execution_plan/execution_plan.h
+++ b/src/execution_plan/execution_plan.h
@@ -56,6 +56,10 @@ void ExecutionPlan_ReplaceOp(ExecutionPlan *plan, OpBase *a, OpBase *b);
  * Returns NULL if operation wasn't found. */
 OpBase* ExecutionPlan_LocateOp(OpBase *root, OPType type);
 
+/* Returns an array of taps; operations which generate data 
+ * e.g. SCAN operations */
+void ExecutionPlan_Taps(OpBase *root, OpBase ***taps);
+
 /* Executes plan */
 ResultSet* ExecutionPlan_Execute(ExecutionPlan *plan);
 

--- a/src/execution_plan/ops/op.h
+++ b/src/execution_plan/ops/op.h
@@ -43,7 +43,7 @@ typedef enum {
     OPType_NODE_BY_ID_SEEK = (1<<21),
 } OPType;
 
-#define OP_SCAN (OPType_ALL_NODE_SCAN | OPType_NODE_BY_LABEL_SCAN | OPType_INDEX_SCAN)
+#define OP_SCAN (OPType_ALL_NODE_SCAN | OPType_NODE_BY_LABEL_SCAN | OPType_INDEX_SCAN | OPType_NODE_BY_ID_SEEK)
 
 typedef enum {
     OP_DEPLETED = 1,

--- a/src/execution_plan/ops/op.h
+++ b/src/execution_plan/ops/op.h
@@ -40,6 +40,7 @@ typedef enum {
     OPType_LIMIT = (1<<18),
     OPType_DISTINCT = (1<<19),
     OPType_EXPAND_INTO = (1<<20),
+    OPType_NODE_BY_ID_SEEK = (1<<21),
 } OPType;
 
 #define OP_SCAN (OPType_ALL_NODE_SCAN | OPType_NODE_BY_LABEL_SCAN | OPType_INDEX_SCAN)

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -76,6 +76,9 @@ Record OpNodeByIdSeekConsume(OpBase *opBase) {
 
     // Did we managed to get an entity?
     if(!n.entity) return NULL;
+    // Null-set the label in case an operation (like op_delete) accesses it.
+    // TODO If we're replacing a label scan, the correct label can be populated now.
+    n.label = NULL;
 
     Record r = Record_New(op->recLength);
     Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -1,0 +1,57 @@
+/*
+* Copyright 2018-2019 Redis Labs Ltd. and Contributors
+*
+* This file is available under the Redis Labs Source Available License Agreement
+*/
+
+#include "op_node_by_id_seek.h"
+
+OpBase* NewOpNodeByIdSeekOp(const AST *ast, Node *n, NodeID nodeId) {
+    OpNodeByIdSeek *op_nodeByIdSeek = malloc(sizeof(OpNodeByIdSeek));    
+    op_nodeByIdSeek->id = nodeId;
+    op_nodeByIdSeek->g = GraphContext_GetFromTLS()->g;
+    op_nodeByIdSeek->nodeRecIdx = AST_GetAliasID(ast, n->alias);
+    op_nodeByIdSeek->recLength = AST_AliasCount(ast);
+    op_nodeByIdSeek->entityRetrieved = false;
+
+    OpBase_Init(&op_nodeByIdSeek->op);
+    op_nodeByIdSeek->op.name = "NodeByIdSeek";
+    op_nodeByIdSeek->op.type = OPType_NODE_BY_ID_SEEK;
+    op_nodeByIdSeek->op.consume = OpNodeByIdSeekConsume;
+    op_nodeByIdSeek->op.reset = OpNodeByIdSeekReset;
+    op_nodeByIdSeek->op.free = OpNodeByIdSeekFree;
+
+    return (OpBase*)op_nodeByIdSeek;
+}
+
+Record OpNodeByIdSeekConsume(OpBase *opBase) {
+    Node n;
+    OpNodeByIdSeek *op = (OpNodeByIdSeek*)opBase;
+    
+    /* Try to get entity by ID 
+     * Incase entity doesn't exists return depleted 
+     * otherwise place entity within recoed and
+     * mark that entity was retrieved. */
+
+    // Can only retrieve entity once.
+    if(op->entityRetrieved) return NULL;
+
+    // See if entity with ID exists in the graph.
+    if(!Graph_GetNode(op->g, op->id, &n)) return NULL;
+    
+    // Managed to get entity, mark and set record.
+    op->entityRetrieved = true;
+    Record r = Record_New(op->recLength);
+    Record_AddNode(r, op->nodeRecIdx, n);
+    return r;
+}
+
+OpResult OpNodeByIdSeekReset(OpBase *ctx) {
+    OpNodeByIdSeek *op = (OpNodeByIdSeek*)ctx;
+    op->entityRetrieved = false;
+    return OP_OK;
+}
+
+void OpNodeByIdSeekFree(OpBase *ctx) {
+
+}

--- a/src/execution_plan/ops/op_node_by_id_seek.h
+++ b/src/execution_plan/ops/op_node_by_id_seek.h
@@ -10,17 +10,43 @@
 #include "../../parser/ast.h"
 #include "../../graph/graph.h"
 
+#define ID_RANGE_UNBOUND -1
+
 /* Node by ID seek locates an entity by its ID */
 typedef struct {
     OpBase op;
-    NodeID id;              // Entity ID to seek.
     Graph *g;               // Graph object.
     int nodeRecIdx;         // Position of entity within record.
     int recLength;          // Size of record.
-    bool entityRetrieved;   // Did we retrived required entity.
+    NodeID minId;           // Min ID to fetch.
+    bool minExclusive;      // Include min ID.
+    NodeID maxId;           // Max ID to fetch.
+    bool maxExclusive;      // Include max ID.
+    NodeID currentId;       // Current ID fetched.
 } OpNodeByIdSeek;
 
-OpBase* NewOpNodeByIdSeekOp(const AST *ast, Node *n, NodeID nodeId);
-Record OpNodeByIdSeekConsume(OpBase *opBase);
-OpResult OpNodeByIdSeekReset(OpBase *ctx);
-void OpNodeByIdSeekFree(OpBase *ctx);
+OpBase* NewOpNodeByIdSeekOp
+(
+    const AST *ast,
+    unsigned int nodeRecIdx,
+    NodeID minId,
+    NodeID maxId,
+    bool includeMin,
+    bool includeMax
+);
+
+Record OpNodeByIdSeekConsume
+(
+    OpBase *opBase
+);
+
+OpResult OpNodeByIdSeekReset
+(
+    OpBase *ctx
+);
+
+void OpNodeByIdSeekFree
+(
+    OpBase *ctx
+);
+

--- a/src/execution_plan/ops/op_node_by_id_seek.h
+++ b/src/execution_plan/ops/op_node_by_id_seek.h
@@ -19,9 +19,9 @@ typedef struct {
     int nodeRecIdx;         // Position of entity within record.
     int recLength;          // Size of record.
     NodeID minId;           // Min ID to fetch.
-    bool minExclusive;      // Include min ID.
+    bool minInclusive;      // Include min ID.
     NodeID maxId;           // Max ID to fetch.
-    bool maxExclusive;      // Include max ID.
+    bool maxInclusive;      // Include max ID.
     NodeID currentId;       // Current ID fetched.
 } OpNodeByIdSeek;
 

--- a/src/execution_plan/ops/op_node_by_id_seek.h
+++ b/src/execution_plan/ops/op_node_by_id_seek.h
@@ -1,0 +1,26 @@
+/*
+* Copyright 2018-2019 Redis Labs Ltd. and Contributors
+*
+* This file is available under the Redis Labs Source Available License Agreement
+*/
+
+#pragma once
+
+#include "op.h"
+#include "../../parser/ast.h"
+#include "../../graph/graph.h"
+
+/* Node by ID seek locates an entity by its ID */
+typedef struct {
+    OpBase op;
+    NodeID id;              // Entity ID to seek.
+    Graph *g;               // Graph object.
+    int nodeRecIdx;         // Position of entity within record.
+    int recLength;          // Size of record.
+    bool entityRetrieved;   // Did we retrived required entity.
+} OpNodeByIdSeek;
+
+OpBase* NewOpNodeByIdSeekOp(const AST *ast, Node *n, NodeID nodeId);
+Record OpNodeByIdSeekConsume(OpBase *opBase);
+OpResult OpNodeByIdSeekReset(OpBase *ctx);
+void OpNodeByIdSeekFree(OpBase *ctx);

--- a/src/execution_plan/ops/ops.h
+++ b/src/execution_plan/ops/ops.h
@@ -29,5 +29,6 @@
 #include "op_skip.h"
 #include "op_limit.h"
 #include "op_expand_into.h"
+#include "op_node_by_id_seek.h"
 
 #endif

--- a/src/execution_plan/optimizations/optimizations.h
+++ b/src/execution_plan/optimizations/optimizations.h
@@ -15,5 +15,6 @@
 #include "./relocate_op.h"
 #include "./reduce_count.h"
 #include "./reduce_distinct.h"
+#include "./seek_by_id.h"
 
 #endif

--- a/src/execution_plan/optimizations/optimizer.c
+++ b/src/execution_plan/optimizations/optimizer.c
@@ -8,6 +8,9 @@
 #include "./optimizations.h"
 
 void optimizePlan(GraphContext *gc, ExecutionPlan *plan, AST *ast) {
+    // Try to reduce SCAN + FILTER to a node seek operation.
+    seekByID(plan, ast);
+
     /* When possible, replace label scan and filter ops
      * with index scans. */
     utilizeIndices(gc, plan, ast);

--- a/src/execution_plan/optimizations/seek_by_id.c
+++ b/src/execution_plan/optimizations/seek_by_id.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#include "seek_by_id.h"
+#include "../../util/arr.h"
+#include "../ops/op_filter.h"
+#include "../ops/op_index_scan.h"
+#include "../ops/op_all_node_scan.h"
+#include "../ops/op_node_by_id_seek.h"
+#include "../ops/op_node_by_label_scan.h"
+
+static bool _idFilter(FT_FilterNode *f, int *rel, EntityID *id) {
+    if(f->t == FT_N_COND) return false;
+    if(f->pred.op == NE) return false;
+    
+    AR_OpNode *op;
+    AR_OperandNode *operand;
+    AR_ExpNode *lhs = f->pred.lhs;
+    AR_ExpNode *rhs = f->pred.rhs;
+    *rel = f->pred.op;
+
+    /* Either ID(N) compare const
+     * OR
+     * const compare ID(N) */
+    if(lhs->type == AR_EXP_OPERAND && rhs->type == AR_EXP_OP) {
+        op = &rhs->op;
+        operand = &lhs->operand;
+    } else if(lhs->type == AR_EXP_OP && rhs->type == AR_EXP_OPERAND) {
+        op = &lhs->op;
+        operand = &rhs->operand;
+    } else {
+        return false;
+    }
+
+    // Make sure ID is compared to a constant.
+    if(operand->type != AR_EXP_CONSTANT) return false;
+    if(SI_TYPE(operand->constant) != T_INT64) return false;
+    *id = SI_GET_NUMERIC(operand->constant);
+
+    // Make sure applied function is ID.
+    if(strcasecmp(op->func_name, "id")) return false;
+
+    return true;
+}
+
+static void _setupIdRange(int rel, EntityID id, NodeID *minId, NodeID *maxId, bool *includeMin, bool *includeMax) {
+    switch(rel) {
+        case GT:
+            *minId = id;
+            break;
+        case GE:
+            *minId = id;
+            *includeMin = true;
+            break;
+        case LT:
+            *maxId = id;
+            break;
+        case LE:
+            *maxId = id;
+            *includeMax = true;
+            break;
+        case EQ:
+            *minId = id;
+            *maxId = id;
+            *includeMin = true;
+            *includeMax = true;
+            break;
+        default:
+            assert(false);
+            break;
+    }
+}
+
+void _reduceTap(ExecutionPlan *plan, const AST *ast, OpBase *tap) {
+    if(tap->type == OPType_ALL_NODE_SCAN ||
+       tap->type == OPType_NODE_BY_LABEL_SCAN ||
+       tap->type == OPType_INDEX_SCAN) {
+        /* See if there's a filter of the form
+         * ID(n) = X
+         * where X is a constant. */
+        OpBase *parent = tap->parent;
+        while(parent && parent->type == OPType_FILTER) {
+            Filter *filter = (Filter*)parent;
+            FT_FilterNode *f = filter->filterTree;
+
+            int rel;
+            EntityID id;
+            if(_idFilter(f, &rel, &id)) {
+                int nodeRecIdx = -1;
+                NodeID minId = ID_RANGE_UNBOUND;
+                NodeID maxId = ID_RANGE_UNBOUND;
+                bool includeMin = false;
+                bool includeMax = false;
+                OpBase *opNodeByIdSeek;
+
+                if(tap->type == OPType_ALL_NODE_SCAN)
+                    nodeRecIdx = ((AllNodeScan*)tap)->nodeRecIdx;
+                else if(tap->type == OPType_NODE_BY_LABEL_SCAN)
+                    nodeRecIdx = ((NodeByLabelScan*)tap)->nodeRecIdx;
+                else if(tap->type == OPType_INDEX_SCAN)
+                    nodeRecIdx = ((IndexScan*)tap)->nodeRecIdx;
+                
+                _setupIdRange(rel, id, &minId, &maxId, &includeMin, &includeMax);
+                opNodeByIdSeek = NewOpNodeByIdSeekOp(ast, nodeRecIdx, minId, maxId,
+                    includeMin, includeMax);
+
+                // Managed to reduce!
+                ExecutionPlan_ReplaceOp(plan, tap, opNodeByIdSeek);
+                ExecutionPlan_RemoveOp(plan, (OpBase*)filter);
+                break;
+            }
+
+            // Advance.
+            parent = parent->parent;
+        }
+    }
+}
+
+void seekByID(ExecutionPlan *plan, const AST *ast) {
+    assert(plan);
+    
+    OpBase **taps = array_new(OpBase*, 1);
+    ExecutionPlan_Taps(plan->root, &taps);
+
+    for(int i = 0; i < array_len(taps); i++) {
+        _reduceTap(plan, ast, taps[i]);
+    }
+
+    array_free(taps);
+}

--- a/src/execution_plan/optimizations/seek_by_id.h
+++ b/src/execution_plan/optimizations/seek_by_id.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2018-2019 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#pragma once
+
+#include "../execution_plan.h"
+
+/* The seek by ID optimization searches for a SCAN operation on which 
+ * a filter of the form ID(n) = X is applied in which case 
+ * both the SCAN and FILTER operations can be reduced into a single 
+ * NODE_BY_ID_SEEK operation. */
+void seekByID(ExecutionPlan *plan, const AST *ast);

--- a/src/util/datablock/datablock_iterator.h
+++ b/src/util/datablock/datablock_iterator.h
@@ -25,8 +25,8 @@ typedef struct DataBlockIterator {
 // Creates a new datablock iterator.
 DataBlockIterator *DataBlockIterator_New (
     Block *block,       // Block from which iteration begins.
-    int64_t start_pos,      // Iteration starts here.
-    int64_t end_pos,        // Iteration stops here.
+    int64_t start_pos,  // Iteration starts here.
+    int64_t end_pos,    // Iteration stops here.
     int step            // To scan entire range, set step to 1.
 );
 

--- a/tests/flow/test_node_by_id.py
+++ b/tests/flow/test_node_by_id.py
@@ -54,12 +54,28 @@ class NodeByIDFlowTest(FlowTestsBase):
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 0 < ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 0 < n.id RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
         
         # All nodes.
         query = """MATCH (n) WHERE ID(n) >= 0 RETURN n ORDER BY n.id"""
         resultsetA = redis_graph.query(query).result_set
         self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
         query = """MATCH (n) WHERE n.id >= 0 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 0 <= ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 0 <= n.id RETURN n ORDER BY n.id"""
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
@@ -81,12 +97,28 @@ class NodeByIDFlowTest(FlowTestsBase):
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 5 < ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 5 < n.id RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
         
         # 5 nodes (5, 6,7,8,9)
         query = """MATCH (n) WHERE ID(n) >= 5 RETURN n ORDER BY n.id"""
         resultsetA = redis_graph.query(query).result_set
         self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
         query = """MATCH (n) WHERE n.id >= 5 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 5 <= ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 5 <= n.id RETURN n ORDER BY n.id"""
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
@@ -99,6 +131,14 @@ class NodeByIDFlowTest(FlowTestsBase):
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 5 < ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 5 < n.id RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
         
         # 6 nodes (0,1,2,3,4,5)
         query = """MATCH (n) WHERE ID(n) <= 5 RETURN n ORDER BY n.id"""
@@ -108,12 +148,28 @@ class NodeByIDFlowTest(FlowTestsBase):
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 5 >= ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 5 >= n.id RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
         
         # All nodes except last one.
         query = """MATCH (n) WHERE ID(n) < 9 RETURN n ORDER BY n.id"""
         resultsetA = redis_graph.query(query).result_set
         self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
         query = """MATCH (n) WHERE n.id < 9 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 9 > ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 9 > n.id RETURN n ORDER BY n.id"""
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
@@ -127,11 +183,27 @@ class NodeByIDFlowTest(FlowTestsBase):
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
 
+        query = """MATCH (n) WHERE 9 >= ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 9 >= n.id RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
         # All nodes.
         query = """MATCH (n) WHERE ID(n) < 100 RETURN n ORDER BY n.id"""
         resultsetA = redis_graph.query(query).result_set
         self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
         query = """MATCH (n) WHERE n.id < 100 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (n) WHERE 100 > ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 100 > n.id RETURN n ORDER BY n.id"""
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
@@ -145,15 +217,29 @@ class NodeByIDFlowTest(FlowTestsBase):
         resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
 
+        query = """MATCH (n) WHERE 100 >= ID(n) RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE 100 >= n.id RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
         # cartesian product, tests reset works as expected.
         query = """MATCH (a), (b) WHERE ID(a) > 5 AND ID(b) <= 5 RETURN a,b ORDER BY a.id, b.id"""
         resultsetA = redis_graph.query(query).result_set
-        print "resultsetA: %s\n" % resultsetA
         self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
         query = """MATCH (a), (b) WHERE a.id > 5 AND b.id <= 5 RETURN a,b ORDER BY a.id, b.id"""
         self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
         resultsetB = redis_graph.query(query).result_set
-        print "resultsetB: %s\n" % resultsetB
+        self.assertEqual(resultsetA, resultsetB)
+
+        query = """MATCH (a), (b) WHERE 5 < ID(a) AND 5 >= ID(b) RETURN a,b ORDER BY a.id, b.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (a), (b) WHERE 5 < a.id AND 5 >= b.id RETURN a,b ORDER BY a.id, b.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
         self.assertEqual(resultsetA, resultsetB)
 
 if __name__ == '__main__':

--- a/tests/flow/test_node_by_id.py
+++ b/tests/flow/test_node_by_id.py
@@ -1,0 +1,160 @@
+import os
+import sys
+import unittest
+from redisgraph import Graph, Node, Edge
+
+import redis
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from disposableredis import DisposableRedis
+
+from base import FlowTestsBase
+
+GRAPH_ID = "g"
+redis_graph = None
+
+def disposable_redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class NodeByIDFlowTest(FlowTestsBase):
+    @classmethod
+    def setUpClass(cls):
+        print "NodeByIDFlowTest"
+        global redis_graph
+        cls.r = disposable_redis()
+        cls.r.start()
+        cls.populate_graph()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+        # pass
+
+    @classmethod
+    def populate_graph(cls):
+        global redis_graph
+        redis_con = cls.r.client()
+        redis_graph = Graph(GRAPH_ID, redis_con)
+        # Create entities
+        for i in range(10):            
+            node = Node(label="person", properties={"id": i})
+            redis_graph.add_node(node)
+        redis_graph.commit()
+
+        # Make sure node id attribute matches node's internal ID.
+        query = """MATCH (n) SET n.id = ID(n)"""
+        redis_graph.query(query)
+
+    # Expect an error when trying to use a function which does not exists.
+    def test_get_nodes(self):
+        # All nodes, not including first node.
+        query = """MATCH (n) WHERE ID(n) > 0 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id > 0 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # All nodes.
+        query = """MATCH (n) WHERE ID(n) >= 0 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id >= 0 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # A single node.
+        query = """MATCH (n) WHERE ID(n) = 0 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id = 0 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # 4 nodes (6,7,8,9)
+        query = """MATCH (n) WHERE ID(n) > 5 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id > 5 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # 5 nodes (5, 6,7,8,9)
+        query = """MATCH (n) WHERE ID(n) >= 5 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id >= 5 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # 5 nodes (0,1,2,3,4)
+        query = """MATCH (n) WHERE ID(n) < 5 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id < 5 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # 6 nodes (0,1,2,3,4,5)
+        query = """MATCH (n) WHERE ID(n) <= 5 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id <= 5 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # All nodes except last one.
+        query = """MATCH (n) WHERE ID(n) < 9 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id < 9 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # All nodes.
+        query = """MATCH (n) WHERE ID(n) <= 9 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id <= 9 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
+        # All nodes.
+        query = """MATCH (n) WHERE ID(n) < 100 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id < 100 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+        
+        # All nodes.
+        query = """MATCH (n) WHERE ID(n) <= 100 RETURN n ORDER BY n.id"""
+        resultsetA = redis_graph.query(query).result_set
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (n) WHERE n.id <= 100 RETURN n ORDER BY n.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        self.assertEqual(resultsetA, resultsetB)
+
+        # cartesian product, tests reset works as expected.
+        query = """MATCH (a), (b) WHERE ID(a) > 5 AND ID(b) <= 5 RETURN a,b ORDER BY a.id, b.id"""
+        resultsetA = redis_graph.query(query).result_set
+        print "resultsetA: %s\n" % resultsetA
+        self.assertIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        query = """MATCH (a), (b) WHERE a.id > 5 AND b.id <= 5 RETURN a,b ORDER BY a.id, b.id"""
+        self.assertNotIn("NodeByIdSeek", redis_graph.execution_plan(query))
+        resultsetB = redis_graph.query(query).result_set
+        print "resultsetB: %s\n" % resultsetB
+        self.assertEqual(resultsetA, resultsetB)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Seek graph entity by ID,
An optimisation which detects a search pattern similar to:
`MATCH (n) WHERE ID(n) = 5 RETURN n`
Will reduce a SCAN + FILTER operations into a single NODE_BY_ID_SEEK operation to quickly locate requested entity.