### PR TITLE
#469 Fix double free of Record in variable length traverse

### DIFF
--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -101,6 +101,7 @@ Record CondVarLenTraverseConsume(OpBase *opBase) {
 OpResult CondVarLenTraverseReset(OpBase *ctx) {
     CondVarLenTraverse *op = (CondVarLenTraverse*)ctx;
     if(op->r) Record_Free(op->r);
+    op->r = NULL;
     AllPathsCtx_Free(op->allPathsCtx);
     op->allPathsCtx = NULL;
     return OP_OK;


### PR DESCRIPTION
Fixes an issue in which a variable length traversal op attempts to free a Record during `CondVarLenTraverseConsume` that has already been freed in the op's Reset function (bug scoped to Cartesian product queries).